### PR TITLE
Support Filtering of Incoming and Outgoing metrics

### DIFF
--- a/agent/ffwd.yaml
+++ b/agent/ffwd.yaml
@@ -31,6 +31,11 @@ input:
         type: udp
 
 output:
+  filter:
+    - "not"
+    - - "and"
+      - ["key", "system"]
+      - ["=", "stat", "p99"]
   plugins:
     - type: noop
       flushInterval: 10000

--- a/core/src/main/java/com/spotify/ffwd/AgentConfig.java
+++ b/core/src/main/java/com/spotify/ffwd/AgentConfig.java
@@ -24,8 +24,6 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
 
-import lombok.Data;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
@@ -34,6 +32,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.spotify.ffwd.input.InputManagerModule;
 import com.spotify.ffwd.output.OutputManagerModule;
+
+import lombok.Data;
 
 @Data
 public class AgentConfig {

--- a/core/src/main/java/com/spotify/ffwd/AgentCore.java
+++ b/core/src/main/java/com/spotify/ffwd/AgentCore.java
@@ -169,7 +169,14 @@ public class AgentCore {
         shutdown.add(output.stop());
         shutdown.add(debug.stop());
 
-        async.collectAndDiscard(shutdown).get();
+        AsyncFuture<Void> all = async.collectAndDiscard(shutdown);
+
+        try {
+            all.get(10, TimeUnit.SECONDS);
+        } catch (final Exception e) {
+            log.error("All components did not stop in a timely fashion", e);
+            all.cancel();
+        }
     }
 
     /**

--- a/core/src/main/java/com/spotify/ffwd/filter/AndFilter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/AndFilter.java
@@ -1,0 +1,68 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.google.common.collect.ImmutableList;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class AndFilter implements Filter {
+    final List<Filter> terms;
+
+    @Override
+    public boolean matchesEvent(Event event) {
+        for (final Filter f : terms) {
+            if (!f.matchesEvent(event)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        for (final Filter f : terms) {
+            if (!f.matchesMetric(metric)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+            final ImmutableList.Builder<Filter> builder = ImmutableList.builder();
+
+            while (p.nextToken() == JsonToken.START_ARRAY) {
+                builder.add(p.readValueAs(Filter.class));
+            }
+
+            if (p.getCurrentToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            final List<Filter> filters = builder.build();
+
+            if (filters.isEmpty()) {
+                return new TrueFilter();
+            }
+
+            if (filters.size() == 1) {
+                return filters.iterator().next();
+            }
+
+            return new AndFilter(filters);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/FalseFilter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/FalseFilter.java
@@ -1,0 +1,36 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class FalseFilter implements Filter {
+    @Override
+    public boolean matchesEvent(Event event) {
+        return false;
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        return false;
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+            if (p.nextToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            return new FalseFilter();
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/Filter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/Filter.java
@@ -1,0 +1,10 @@
+package com.spotify.ffwd.filter;
+
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+public interface Filter {
+    public boolean matchesEvent(Event event);
+
+    public boolean matchesMetric(Metric metric);
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/FilterDeserializer.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/FilterDeserializer.java
@@ -1,0 +1,52 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A filter deserializer.
+ *
+ * Filters are represented as array where the first element in the array is the filter identifier, and the rest are
+ * arguments to that filter.
+ *
+ * @author udoprog
+ */
+@RequiredArgsConstructor
+public class FilterDeserializer extends JsonDeserializer<Filter> {
+    final Map<String, PartialDeserializer> suppliers;
+
+    @Override
+    public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+        if (p.getCurrentToken() != JsonToken.START_ARRAY) {
+            throw ctx.wrongTokenException(p, JsonToken.START_ARRAY, null);
+        }
+
+        final String id = p.nextTextValue();
+
+        final PartialDeserializer d = suppliers.get(id);
+
+        if (d == null) {
+            throw ctx.weirdStringException(id, Filter.class, String.format("Expected one of %s", suppliers.keySet()));
+        }
+
+        final Filter instance = d.deserialize(p, ctx);
+
+        if (p.getCurrentToken() != JsonToken.END_ARRAY) {
+            throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+        }
+
+        return instance;
+    }
+
+    public static interface PartialDeserializer {
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException;
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/MatchKey.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/MatchKey.java
@@ -1,0 +1,41 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class MatchKey implements Filter {
+    private final String value;
+
+    @Override
+    public boolean matchesEvent(Event event) {
+        return event.getKey().equals(value);
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        return metric.getKey().equals(value);
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx)
+                throws IOException, JsonProcessingException {
+            final String key = p.nextTextValue();
+
+            if (p.nextToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            return new MatchKey(key);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/MatchTag.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/MatchTag.java
@@ -1,0 +1,54 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class MatchTag implements Filter {
+    private final String key;
+    private final String value;
+
+    @Override
+    public boolean matchesEvent(final Event event) {
+        final String value = event.getAttributes().get(key);
+
+        if (value == null) {
+            return false;
+        }
+
+        return value.equals(this.value);
+    }
+
+    @Override
+    public boolean matchesMetric(final Metric metric) {
+        final String value = metric.getAttributes().get(key);
+
+        if (value == null) {
+            return false;
+        }
+
+        return value.equals(this.value);
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+            final String key = p.nextTextValue();
+            final String value = p.nextTextValue();
+
+            if (p.nextToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            return new MatchTag(key, value);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/NotFilter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/NotFilter.java
@@ -1,0 +1,45 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class NotFilter implements Filter {
+    final Filter filter;
+
+    @Override
+    public boolean matchesEvent(Event event) {
+        return !filter.matchesEvent(event);
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        return !filter.matchesMetric(metric);
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx)
+                throws IOException, JsonProcessingException {
+            if (p.nextToken() != JsonToken.START_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.START_ARRAY, null);
+            }
+
+            final Filter filter = p.readValueAs(Filter.class);
+
+            if (p.nextToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            return new NotFilter(filter);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/OrFilter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/OrFilter.java
@@ -1,0 +1,68 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.google.common.collect.ImmutableList;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class OrFilter implements Filter {
+    final List<Filter> terms;
+
+    @Override
+    public boolean matchesEvent(Event event) {
+        for (final Filter f : terms) {
+            if (f.matchesEvent(event)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        for (final Filter f : terms) {
+            if (f.matchesMetric(metric)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+            final ImmutableList.Builder<Filter> builder = ImmutableList.builder();
+
+            while (p.nextToken() == JsonToken.START_ARRAY) {
+                builder.add(p.readValueAs(Filter.class));
+            }
+
+            if (p.getCurrentToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            final List<Filter> filters = builder.build();
+
+            if (filters.isEmpty()) {
+                return new FalseFilter();
+            }
+
+            if (filters.size() == 1) {
+                return filters.iterator().next();
+            }
+
+            return new OrFilter(filters);
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/filter/TrueFilter.java
+++ b/core/src/main/java/com/spotify/ffwd/filter/TrueFilter.java
@@ -1,0 +1,36 @@
+package com.spotify.ffwd.filter;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+
+import lombok.Data;
+
+@Data
+public class TrueFilter implements Filter {
+    @Override
+    public boolean matchesEvent(Event event) {
+        return true;
+    }
+
+    @Override
+    public boolean matchesMetric(Metric metric) {
+        return true;
+    }
+
+    public static class Deserializer implements FilterDeserializer.PartialDeserializer {
+        @Override
+        public Filter deserialize(JsonParser p, DeserializationContext ctx) throws IOException, JsonProcessingException {
+            if (p.nextToken() != JsonToken.END_ARRAY) {
+                throw ctx.wrongTokenException(p, JsonToken.END_ARRAY, null);
+            }
+
+            return new TrueFilter();
+        }
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/input/CoreInputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/input/CoreInputManager.java
@@ -19,11 +19,10 @@ package com.spotify.ffwd.input;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.ToString;
-
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.spotify.ffwd.debug.DebugServer;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import com.spotify.ffwd.output.OutputManager;
@@ -31,6 +30,7 @@ import com.spotify.ffwd.statistics.InputManagerStatistics;
 
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
+import lombok.ToString;
 
 /**
  * Responsible for receiving, logging and transforming the event.
@@ -56,14 +56,23 @@ public class CoreInputManager implements InputManager {
     @Inject
     private InputManagerStatistics statistics;
 
+    @Inject
+    private Filter filter;
+
     @Override
     public void init() {
-        for (final PluginSource s : sources)
+        for (final PluginSource s : sources) {
             s.init();
+        }
     }
 
     @Override
     public void receiveEvent(Event event) {
+        if (!filter.matchesEvent(event)) {
+            statistics.reportEventsDroppedByFilter(1);
+            return;
+        }
+
         statistics.reportReceivedEvents(1);
         debug.inspectEvent(DEBUG_ID, event);
         output.sendEvent(event);
@@ -71,6 +80,11 @@ public class CoreInputManager implements InputManager {
 
     @Override
     public void receiveMetric(Metric metric) {
+        if (!filter.matchesMetric(metric)) {
+            statistics.reportMetricsDroppedByFilter(1);
+            return;
+        }
+
         statistics.reportReceivedMetrics(1);
         debug.inspectMetric(DEBUG_ID, metric);
         output.sendMetric(metric);

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -35,6 +35,8 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.spotify.ffwd.AgentConfig;
+import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.filter.TrueFilter;
 import com.spotify.ffwd.statistics.CoreStatistics;
 import com.spotify.ffwd.statistics.OutputManagerStatistics;
 
@@ -42,10 +44,12 @@ public class OutputManagerModule {
     private final List<OutputPlugin> DEFAULT_PLUGINS = Lists.newArrayList();
 
     private final List<OutputPlugin> plugins;
+    private final Filter filter;
 
     @JsonCreator
-    public OutputManagerModule(@JsonProperty("plugins") List<OutputPlugin> plugins) {
+    public OutputManagerModule(@JsonProperty("plugins") List<OutputPlugin> plugins, @JsonProperty("filter") Filter filter) {
         this.plugins = Optional.of(plugins).or(DEFAULT_PLUGINS);
+        this.filter = Optional.fromNullable(filter).or(new TrueFilter());
     }
 
     public Module module() {
@@ -90,6 +94,12 @@ public class OutputManagerModule {
                 return config.getTtl();
             }
 
+            @Provides
+            @Singleton
+            public Filter filter() {
+                return filter;
+            }
+
             @Override
             protected void configure() {
                 bind(OutputManager.class).to(CoreOutputManager.class).in(Scopes.SINGLETON);
@@ -117,7 +127,7 @@ public class OutputManagerModule {
         return new Supplier<OutputManagerModule>() {
             @Override
             public OutputManagerModule get() {
-                return new OutputManagerModule(null);
+                return new OutputManagerModule(null, null);
             }
         };
     }

--- a/core/src/test/java/com/spotify/ffwd/filter/FilterDeserializerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/filter/FilterDeserializerTest.java
@@ -1,0 +1,39 @@
+package com.spotify.ffwd.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class FilterDeserializerTest {
+    ObjectMapper mapper;
+
+    @Before
+    public void setup() {
+        final SimpleModule m = new SimpleModule();
+
+        final Map<String, FilterDeserializer.PartialDeserializer> filters = new HashMap<>();
+        filters.put("and", new AndFilter.Deserializer());
+        filters.put("or", new OrFilter.Deserializer());
+        filters.put("key", new MatchKey.Deserializer());
+        filters.put("not", new NotFilter.Deserializer());
+
+        m.addDeserializer(Filter.class, new FilterDeserializer(filters));
+
+        mapper = new ObjectMapper();
+        mapper.registerModule(m);
+    }
+
+    @Test
+    public void testArray() throws Exception {
+        assertEquals(new MatchKey("value"), mapper.readValue("[\"key\", \"value\"]", Filter.class));
+        assertEquals(new FalseFilter(), mapper.readValue("[\"or\"]", Filter.class));
+        assertEquals(new MatchKey("value"), mapper.readValue("[\"or\", [\"key\", \"value\"]]", Filter.class));
+    }
+}

--- a/module/src/main/java/com/spotify/ffwd/statistics/InputManagerStatistics.java
+++ b/module/src/main/java/com/spotify/ffwd/statistics/InputManagerStatistics.java
@@ -20,4 +20,22 @@ public interface InputManagerStatistics {
     public void reportReceivedMetrics(int received);
 
     public void reportReceivedEvents(int received);
+
+    /**
+     * Reported that the given number of events were dropped by a filter.
+     *
+     * Filtered events are <em>not</em> sent to output plugins.
+     *
+     * @param filtered The number of filtered events.
+     */
+    public void reportEventsDroppedByFilter(int dropped);
+
+    /**
+     * Reported that the given number of metrics were dropped by a filter.
+     *
+     * Filtered metrics are <em>not</em> sent to output plugins.
+     *
+     * @param filtered The number of filtered metrics.
+     */
+    public void reportMetricsDroppedByFilter(int dropped);
 }

--- a/module/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/module/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -25,6 +25,14 @@ public class NoopCoreStatistics implements CoreStatistics {
         @Override
         public void reportReceivedEvents(int received) {
         }
+
+        @Override
+        public void reportEventsDroppedByFilter(int dropped) {
+        }
+
+        @Override
+        public void reportMetricsDroppedByFilter(int dropped) {
+        }
     };
 
     @Override
@@ -39,6 +47,14 @@ public class NoopCoreStatistics implements CoreStatistics {
 
         @Override
         public void reportSentEvents(int sent) {
+        }
+
+        @Override
+        public void reportEventsDroppedByFilter(int dropped) {
+        }
+
+        @Override
+        public void reportMetricsDroppedByFilter(int dropped) {
         }
     };
 

--- a/module/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
+++ b/module/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
@@ -30,4 +30,22 @@ public interface OutputManagerStatistics {
      * @param sent The number of metrics sent.
      */
     public void reportSentMetrics(int sent);
+
+    /**
+     * Reported that the given number of events were filtered.
+     *
+     * Filtered events are <em>not</em> sent to output plugins.
+     *
+     * @param filtered The number of filtered events.
+     */
+    public void reportEventsDroppedByFilter(int dropped);
+
+    /**
+     * Reported that the given number of metrics were filtered.
+     *
+     * Filtered metrics are <em>not</em> sent to output plugins.
+     *
+     * @param filtered The number of filtered metrics.
+     */
+    public void reportMetricsDroppedByFilter(int dropped);
 }


### PR DESCRIPTION
This patch implements filtering through a JSON-based filtering language.

This allows the operator to implement filters that targets very specific things, like a specific tag combination.

The `filter` option will not be available in the `input.filter` and `output.filter` parts of the configuration, this is expected to be an array (as exemplified in the changes to `agent/ffwd.yaml`).
