### PR TITLE
Distribute nodes across Kafka partitions more evenly

### DIFF
--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPartitioner.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPartitioner.java
@@ -24,6 +24,7 @@ import com.spotify.ffwd.model.Metric;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+import java.util.zip.CRC32;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
@@ -43,7 +44,9 @@ public interface KafkaPartitioner {
 
         @Override
         public int partition(final Event event) {
-            return event.getHost().hashCode();
+            final CRC32 crcGenerator = new CRC32();
+            crcGenerator.update(event.getHost().getBytes());
+            return (int) crcGenerator.getValue();
         }
 
         @Override


### PR DESCRIPTION
The current mechanism to assign metrics to a Kafka partition
based on the hostname.hashCode() does not generate a distribution even
enough and create some hot spots in our Kafka cluster. By calculating a
CRC32 of the hostname and using that instead we create a more even
distribution, according to our tests.