### PR TITLE
Ffwd Output: Extend filtering functionality

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/filter/Filter.java
+++ b/api/src/main/java/com/spotify/ffwd/filter/Filter.java
@@ -15,11 +15,16 @@
  */
 package com.spotify.ffwd.filter;
 
+import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 
 public interface Filter {
-    public boolean matchesEvent(Event event);
+    boolean matchesEvent(Event event);
 
-    public boolean matchesMetric(Metric metric);
+    boolean matchesMetric(Metric metric);
+
+    default boolean matchesBatch(Batch batch) {
+        return true;
+    }
 }

--- a/api/src/main/java/com/spotify/ffwd/input/InputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/input/InputPlugin.java
@@ -23,7 +23,5 @@ import com.google.inject.Module;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public interface InputPlugin {
-    public Module module(Key<PluginSource> key, String id);
-
-    public String id(int index);
+    Module module(Key<PluginSource> key, String id);
 }

--- a/api/src/main/java/com/spotify/ffwd/output/BatchedPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/BatchedPluginSink.java
@@ -28,7 +28,7 @@ public interface BatchedPluginSink extends PluginSink {
      * @param events Collection of events to send.
      * @return A future that will be resolved when the events have been sent.
      */
-    public AsyncFuture<Void> sendEvents(Collection<Event> events);
+    AsyncFuture<Void> sendEvents(Collection<Event> events);
 
     /**
      * Send the given collection of metrics.
@@ -36,7 +36,7 @@ public interface BatchedPluginSink extends PluginSink {
      * @param metrics Metrics to send.
      * @return A future that will be resolved when the metrics have been sent.
      */
-    public AsyncFuture<Void> sendMetrics(Collection<Metric> metrics);
+    AsyncFuture<Void> sendMetrics(Collection<Metric> metrics);
 
     /**
      * Send the given collection of batches.
@@ -44,5 +44,5 @@ public interface BatchedPluginSink extends PluginSink {
      * @param batches Batches to send.
      * @return A future that will be resolved when the batches have been sent.
      */
-    public AsyncFuture<Void> sendBatches(Collection<Batch> batches);
+    AsyncFuture<Void> sendBatches(Collection<Batch> batches);
 }

--- a/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2017 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.output;
+
+import com.google.inject.Inject;
+import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import eu.toolchain.async.AsyncFuture;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FilteringPluginSink implements PluginSink {
+    @Inject
+    protected PluginSink sink;
+
+    protected Filter filter;
+
+    public FilteringPluginSink(final Filter filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public void init() {
+        sink.init();
+    }
+
+    @Override
+    public void sendEvent(final Event event) {
+        if (filter.matchesEvent(event)) {
+            sink.sendEvent(event);
+        }
+    }
+
+    @Override
+    public void sendMetric(final Metric metric) {
+        if (filter.matchesMetric(metric)) {
+            sink.sendMetric(metric);
+        }
+    }
+
+    @Override
+    public void sendBatch(final Batch batch) {
+        if (filter.matchesBatch(batch)) {
+            sink.sendBatch(batch);
+        }
+    }
+
+    @Override
+    public AsyncFuture<Void> start() {
+        log.info("Starting filtering sink {}", filter);
+        return sink.start();
+    }
+
+    @Override
+    public AsyncFuture<Void> stop() {
+        return sink.stop();
+    }
+
+    @Override
+    public boolean isReady() {
+        return sink.isReady();
+    }
+}

--- a/api/src/main/java/com/spotify/ffwd/output/FlushingPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FlushingPluginSink.java
@@ -16,6 +16,7 @@
 package com.spotify.ffwd.output;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
@@ -36,7 +37,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import javax.inject.Named;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 
@@ -47,6 +48,7 @@ import org.slf4j.Logger;
  * @author udoprog
  */
 @RequiredArgsConstructor
+@Data
 public class FlushingPluginSink implements PluginSink {
     public static final long DEFAULT_BATCH_SIZE_LIMIT = 10000;
     public static final long DEFAULT_MAX_PENDING_FLUSHES = 10;
@@ -185,14 +187,9 @@ public class FlushingPluginSink implements PluginSink {
 
     @Override
     public AsyncFuture<Void> start() {
-        log.info("Starting (Filter: {})", filter);
-
-        return sink.start().transform(new Transform<Void, Void>() {
-            @Override
-            public Void transform(Void result) throws Exception {
-                scheduleNext();
-                return null;
-            }
+        return sink.start().transform((Transform<Void, Void>) result -> {
+            scheduleNext();
+            return null;
         });
     }
 

--- a/api/src/main/java/com/spotify/ffwd/output/OutputDelegatingModule.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputDelegatingModule.java
@@ -15,29 +15,20 @@
  */
 package com.spotify.ffwd.output;
 
-import com.spotify.ffwd.Initializable;
-import com.spotify.ffwd.model.Batch;
-import com.spotify.ffwd.model.Event;
-import com.spotify.ffwd.model.Metric;
-import eu.toolchain.async.AsyncFuture;
+import com.google.inject.Key;
+import com.google.inject.PrivateModule;
+import lombok.Data;
 
-public interface OutputManager extends Initializable {
-    /**
-     * Send a collection of events to all output plugins.
-     */
-    void sendEvent(Event event);
+@Data
+public class OutputDelegatingModule<T extends PluginSink> extends PrivateModule {
+    private final Key<PluginSink> input;
+    private final Key<PluginSink> output;
+    private final T impl;
 
-    /**
-     * Send a collection of metrics to all output plugins.
-     */
-    void sendMetric(Metric metric);
-
-    /**
-     * Send a batch collection of metrics to all output plugins.
-     */
-    void sendBatch(Batch batch);
-
-    AsyncFuture<Void> start();
-
-    AsyncFuture<Void> stop();
+    @Override
+    protected void configure() {
+        bind(input.getTypeLiteral()).to(input);
+        bind(output).toInstance(impl);
+        expose(output);
+    }
 }

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
@@ -20,10 +20,83 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.name.Names;
+import com.spotify.ffwd.filter.Filter;
+import java.util.Optional;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
-public interface OutputPlugin {
-    public Module module(Key<PluginSink> key, String id);
+public abstract class OutputPlugin {
 
-    public String id(int index);
+    protected final Optional<Long> flushInterval;
+    protected final Optional<Filter> filter;
+
+    public OutputPlugin() {
+        filter = Optional.empty();
+        flushInterval = Optional.empty();
+    }
+
+    public OutputPlugin(
+        final Optional<Filter> filter, final Optional<Long> flushInterval
+    ) {
+        this.filter = filter;
+        this.flushInterval = flushInterval;
+    }
+
+    /**
+     * This method allows to wrap plugin sink implementation type depending on configuration.
+     * If no additional configuration is specified then subtype of
+     * com.spotify.ffwd.output.BatchedPluginSink will be bound per plugin.
+     *
+     * <code>output := new SubtypeOfBatchedPluginSink()</code>
+     *
+     * If 'flushInterval' key is specified, then corresponding subtype of
+     * com.spotify.ffwd.output.BatchedPluginSink will be wrapped into
+     * com.spotify.ffwd.output.FlushingPluginSink:
+     *
+     * <code>output := new FlushingPluginSink(flushInterval, delegator:=output)</code>
+     *
+     * The resulting plugin sink type may be further wrapped into
+     * com.spotify.ffwd.output.FilteringPluginSink type if 'filter' key is specified
+     * in plugin configuration:
+     *
+     * <code>output := new FilteringPluginSink(filter, delegator:=output)</code>
+     *
+     * @param  input   binding key with injection type of plugin sink
+     * @param  output  binding key, containing injection type of wrapping plugin sink
+     * @return module that exposes output binding key
+     */
+    protected Module wrapPluginSink(
+        final Key<? extends PluginSink> input, final Key<PluginSink> output
+    ) {
+        return new PrivateModule() {
+            @Override
+            protected void configure() {
+                Key<PluginSink> sinkKey = (Key<PluginSink>) input;
+
+                if (flushInterval != null && flushInterval.isPresent() &&
+                    BatchedPluginSink.class.isAssignableFrom(
+                        sinkKey.getTypeLiteral().getRawType())) {
+                    final Key<PluginSink> flushingKey =
+                        Key.get(PluginSink.class, Names.named("flushing"));
+                    install(new OutputDelegatingModule<>(sinkKey, flushingKey,
+                        new FlushingPluginSink(flushInterval.get())));
+                    sinkKey = flushingKey;
+                }
+
+                if (filter != null && filter.isPresent()) {
+                    final Key<PluginSink> filteringKey =
+                        Key.get(PluginSink.class, Names.named("filtered"));
+                    install(new OutputDelegatingModule<>(sinkKey, filteringKey,
+                        new FilteringPluginSink(filter.get())));
+                    sinkKey = filteringKey;
+                }
+
+                bind(output).to(sinkKey);
+                expose(output);
+            }
+        };
+    }
+
+    public abstract Module module(Key<PluginSink> key, String id);
 }

--- a/api/src/main/java/com/spotify/ffwd/output/PluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/PluginSink.java
@@ -30,7 +30,7 @@ public interface PluginSink extends Initializable {
      * @param events Collection of events to send.
      * @return A future that will be resolved when the events have been sent.
      */
-    public void sendEvent(Event event);
+    void sendEvent(Event event);
 
     /**
      * Send the given collection of metrics.
@@ -40,7 +40,7 @@ public interface PluginSink extends Initializable {
      * @param metrics Metrics to send.
      * @return A future that will be resolved when the metrics have been sent.
      */
-    public void sendMetric(Metric metric);
+    void sendMetric(Metric metric);
 
     /**
      * Send the given collection of metrics.
@@ -50,11 +50,11 @@ public interface PluginSink extends Initializable {
      * @param batch Batch to send.
      * @return A future that will be resolved when the metrics have been sent.
      */
-    public void sendBatch(Batch batch);
+    void sendBatch(Batch batch);
 
-    public AsyncFuture<Void> start();
+    AsyncFuture<Void> start();
 
-    public AsyncFuture<Void> stop();
+    AsyncFuture<Void> stop();
 
-    public boolean isReady();
+    boolean isReady();
 }

--- a/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
@@ -1,0 +1,111 @@
+package com.spotify.ffwd.output;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.ffwd.filter.MatchKey;
+import com.spotify.ffwd.filter.MatchTag;
+import com.spotify.ffwd.filter.NotFilter;
+import com.spotify.ffwd.filter.TrueFilter;
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import java.util.Date;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilteringPluginSinkTest {
+
+    @Mock
+    private FlushingPluginSink childSink;
+    private FilteringPluginSink sink;
+
+    private Metric metric;
+    private Event event;
+    private Batch batch;
+
+    @Before
+    public void setup() {
+        sink = spy(new FilteringPluginSink(new TrueFilter()));
+        sink.sink = childSink;
+        metric = new Metric("test_metric", 1278, new Date(), "", ImmutableSet.of(),
+            ImmutableMap.of("what", "stats", "pod", "gew1"), "test_proc");
+        event =
+            new Event("test_event", 1278, new Date(), 12L, "critical", "test_event", "test_host",
+                ImmutableSet.of(), ImmutableMap.of("what", "stats", "pod", "gew1"));
+        batch = new Batch(ImmutableMap.of("what", "stats", "pod", "gew1"), ImmutableList.of());
+    }
+
+    @Test
+    public void testSendMetricTrueFilter() {
+        doNothing().when(childSink).sendMetric(metric);
+        ArgumentCaptor<Metric> captor = ArgumentCaptor.forClass(Metric.class);
+
+        sink.sendMetric(metric);
+        verify(childSink, times(1)).sendMetric(captor.capture());
+
+        Metric sentMetric = captor.getValue();
+        assertEquals("test_metric", sentMetric.getKey());
+    }
+
+    @Test
+    public void testSendMetricNotFilter() {
+        sink.filter = new NotFilter(new MatchKey(metric.getKey()));
+        doNothing().when(childSink).sendMetric(metric);
+        ArgumentCaptor<Metric> captor = ArgumentCaptor.forClass(Metric.class);
+
+        sink.sendMetric(metric);
+        verify(childSink, times(0)).sendMetric(captor.capture());
+    }
+
+    @Test
+    public void testSendEventTrueFilter() {
+        sink.filter = new TrueFilter();
+        doNothing().when(childSink).sendEvent(event);
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+
+        sink.sendEvent(event);
+        verify(childSink, times(1)).sendEvent(captor.capture());
+
+        Event sentEvent = captor.getValue();
+        assertEquals("test_event", sentEvent.getKey());
+    }
+
+    @Test
+    public void testSendEventMatchTagFilter() {
+        sink.filter = new MatchTag("pod", "gew1");
+        doNothing().when(childSink).sendEvent(event);
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+
+        sink.sendEvent(event);
+        verify(childSink, times(1)).sendEvent(captor.capture());
+
+        Event sentEvent = captor.getValue();
+        assertEquals("test_event", sentEvent.getKey());
+    }
+
+    @Test
+    public void testSendBatchTrueFilter() {
+        sink.filter = new TrueFilter();
+        doNothing().when(childSink).sendEvent(event);
+        ArgumentCaptor<Batch> captor = ArgumentCaptor.forClass(Batch.class);
+
+        sink.sendBatch(batch);
+        verify(childSink, times(1)).sendBatch(captor.capture());
+
+        Batch sentBatch = captor.getValue();
+        assertEquals("gew1", sentBatch.getCommonTags().get("pod"));
+        assertEquals("stats", sentBatch.getCommonTags().get("what"));
+    }
+}

--- a/core/src/main/java/com/spotify/ffwd/AgentCore.java
+++ b/core/src/main/java/com/spotify/ffwd/AgentCore.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.AbstractModule;
@@ -36,6 +37,7 @@ import com.spotify.ffwd.debug.DebugServer;
 import com.spotify.ffwd.debug.NettyDebugServer;
 import com.spotify.ffwd.debug.NoopDebugServer;
 import com.spotify.ffwd.filter.AndFilter;
+import com.spotify.ffwd.filter.FalseFilter;
 import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.filter.FilterDeserializer;
 import com.spotify.ffwd.filter.MatchKey;
@@ -78,7 +80,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -151,7 +152,7 @@ public class AgentCore {
     }
 
     private void start(final Injector primary)
-        throws Exception, InterruptedException, ExecutionException {
+        throws Exception {
         final InputManager input = primary.getInstance(InputManager.class);
         final OutputManager output = primary.getInstance(OutputManager.class);
         final DebugServer debug = primary.getInstance(DebugServer.class);
@@ -213,7 +214,7 @@ public class AgentCore {
                 filters.put("key", new MatchKey.Deserializer());
                 filters.put("=", new MatchTag.Deserializer());
                 filters.put("true", new TrueFilter.Deserializer());
-                filters.put("false", new TrueFilter.Deserializer());
+                filters.put("false", new FalseFilter.Deserializer());
                 filters.put("and", new AndFilter.Deserializer());
                 filters.put("or", new OrFilter.Deserializer());
                 filters.put("not", new NotFilter.Deserializer());
@@ -223,7 +224,7 @@ public class AgentCore {
 
             @Singleton
             @Provides
-            @Named("application/yaml+config")
+            @Named("config")
             public SimpleModule configModule(
                 Map<String, FilterDeserializer.PartialDeserializer> filters
             ) {
@@ -372,8 +373,9 @@ public class AgentCore {
     private AgentConfig readConfig(Injector early) throws IOException {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final SimpleModule module =
-            early.getInstance(Key.get(SimpleModule.class, Names.named("application/yaml+config")));
+            early.getInstance(Key.get(SimpleModule.class, Names.named("config")));
 
+        mapper.registerModule(new Jdk8Module());
         mapper.registerModule(module);
 
         try (final InputStream input = Files.newInputStream(this.config)) {

--- a/core/src/main/java/com/spotify/ffwd/generated/GeneratedInputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/generated/GeneratedInputPlugin.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import java.util.Optional;
@@ -28,7 +29,9 @@ public class GeneratedInputPlugin implements InputPlugin {
     private final boolean sameHost;
 
     @JsonCreator
-    public GeneratedInputPlugin(@JsonProperty("sameHost") Boolean sameHost) {
+    public GeneratedInputPlugin(
+        @JsonProperty("sameHost") Boolean sameHost, @JsonProperty("filter") Optional<Filter> filter
+    ) {
         this.sameHost = Optional.ofNullable(sameHost).orElse(false);
     }
 
@@ -41,10 +44,5 @@ public class GeneratedInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%d]", getClass().getPackage().getName(), index);
     }
 }

--- a/core/src/main/java/com/spotify/ffwd/input/InputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/input/InputManagerModule.java
@@ -85,11 +85,10 @@ public class InputManagerModule {
                     Multibinder.newSetBinder(binder(), PluginSource.class);
 
                 int i = 0;
-
                 for (final InputPlugin p : plugins) {
-                    final String id = p.id(i++);
+                    final String id = String.valueOf(++i);
                     final Key<PluginSource> k = Key.get(PluginSource.class, Names.named(id));
-                    install(p.module(k, id));
+                    install(p.module(k, String.valueOf(id)));
                     sources.addBinding().to(k);
                 }
             }

--- a/core/src/main/java/com/spotify/ffwd/noop/NoopOutputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/noop/NoopOutputPlugin.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.output.BatchedPluginSink;
 import com.spotify.ffwd.output.FlushingPluginSink;
 import com.spotify.ffwd.output.OutputPlugin;
@@ -28,15 +29,17 @@ import com.spotify.ffwd.output.PluginSink;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-public class NoopOutputPlugin implements OutputPlugin {
+public class NoopOutputPlugin extends OutputPlugin {
     private static final long DEFAULT_FLUSH_INTERVAL =
         TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS);
 
-    private final Long flushInterval;
-
     @JsonCreator
-    public NoopOutputPlugin(@JsonProperty("flushInterval") Long flushInterval) {
-        this.flushInterval = Optional.ofNullable(flushInterval).orElse(DEFAULT_FLUSH_INTERVAL);
+    public NoopOutputPlugin(
+        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("filter") Optional<Filter> filter
+    ) {
+        super(filter,
+            flushInterval.isPresent() ? flushInterval : Optional.of(DEFAULT_FLUSH_INTERVAL));
     }
 
     @Override
@@ -46,7 +49,7 @@ public class NoopOutputPlugin implements OutputPlugin {
             protected void configure() {
                 if (flushInterval != null) {
                     bind(BatchedPluginSink.class).to(NoopPluginSink.class).in(Scopes.SINGLETON);
-                    bind(key).toInstance(new FlushingPluginSink(flushInterval));
+                    bind(key).toInstance(new FlushingPluginSink(flushInterval.get()));
                 } else {
                     bind(key).to(NoopPluginSink.class).in(Scopes.SINGLETON);
                 }
@@ -56,8 +59,4 @@ public class NoopOutputPlugin implements OutputPlugin {
         };
     }
 
-    @Override
-    public String id(int index) {
-        return Integer.toString(index);
-    }
 }

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -135,7 +135,7 @@ public class OutputManagerModule {
                 int i = 0;
 
                 for (final OutputPlugin p : plugins) {
-                    final String id = p.id(i++);
+                    final String id = String.valueOf(++i);
                     final Key<PluginSink> k = Key.get(PluginSink.class, Names.named(id));
                     install(p.module(k, id));
                     sinks.addBinding().to(k);

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -25,7 +25,7 @@ purpose.
 
 * _com.spotify.ffwd.module.PluginContext_
   Register input and output plugins.
-* _com.fasterxml.jackson.databind.ObjectMapper (application/yaml+config)_
+* _com.fasterxml.jackson.databind.ObjectMapper (config)_
   ObjectMapper used to parse provided configuration file.
 
 #### Primary Injector

--- a/modules/carbon/src/main/java/com/spotify/ffwd/carbon/CarbonInputPlugin.java
+++ b/modules/carbon/src/main/java/com/spotify/ffwd/carbon/CarbonInputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.protocol.Protocol;
@@ -48,7 +49,8 @@ public class CarbonInputPlugin implements InputPlugin {
     public CarbonInputPlugin(
         @JsonProperty("protocol") final ProtocolFactory protocol,
         @JsonProperty("delimiter") final String delimiter,
-        @JsonProperty("retry") final RetryPolicy retry, @JsonProperty("key") final String key
+        @JsonProperty("retry") final RetryPolicy retry, @JsonProperty("key") final String key,
+        @JsonProperty("filter") Optional<Filter> filter
     ) {
         this.protocol = Optional
             .ofNullable(protocol)
@@ -106,10 +108,5 @@ public class CarbonInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%s]", getClass().getPackage().getName(), protocol.toString());
     }
 }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpInputPlugin.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpInputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.protocol.Protocol;
@@ -40,7 +41,8 @@ public class HttpInputPlugin implements InputPlugin {
 
     @JsonCreator
     public HttpInputPlugin(
-        @JsonProperty("protocol") ProtocolFactory protocol, @JsonProperty("retry") RetryPolicy retry
+        @JsonProperty("protocol") ProtocolFactory protocol,
+        @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter
     ) {
         this.protocol = Optional
             .ofNullable(protocol)
@@ -72,10 +74,5 @@ public class HttpInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%s]", getClass().getPackage().getName(), protocol.toString());
     }
 }

--- a/modules/json/src/main/java/com/spotify/ffwd/json/JsonInputPlugin.java
+++ b/modules/json/src/main/java/com/spotify/ffwd/json/JsonInputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.protocol.Protocol;
@@ -46,7 +47,8 @@ public class JsonInputPlugin implements InputPlugin {
     @JsonCreator
     public JsonInputPlugin(
         @JsonProperty("protocol") ProtocolFactory protocol,
-        @JsonProperty("delimiter") String delimiter, @JsonProperty("retry") RetryPolicy retry
+        @JsonProperty("delimiter") String delimiter, @JsonProperty("retry") RetryPolicy retry,
+        @JsonProperty("filter") Optional<Filter> filter
     ) {
         this.protocol = Optional
             .ofNullable(protocol)
@@ -107,10 +109,5 @@ public class JsonInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%s]", getClass().getPackage().getName(), protocol.toString());
     }
 }

--- a/modules/protobuf/src/main/java/com/spotify/ffwd/protobuf/ProtobufInputPlugin.java
+++ b/modules/protobuf/src/main/java/com/spotify/ffwd/protobuf/ProtobufInputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.protocol.Protocol;
@@ -40,7 +41,8 @@ public class ProtobufInputPlugin implements InputPlugin {
 
     @JsonCreator
     public ProtobufInputPlugin(
-        @JsonProperty("protocol") ProtocolFactory protocol, @JsonProperty("retry") RetryPolicy retry
+        @JsonProperty("protocol") ProtocolFactory protocol,
+        @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter
     ) {
         this.protocol = Optional
             .ofNullable(protocol)
@@ -76,10 +78,5 @@ public class ProtobufInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%s]", getClass().getPackage().getName(), protocol.toString());
     }
 }

--- a/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannInputPlugin.java
+++ b/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannInputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.protocol.Protocol;
@@ -44,7 +45,8 @@ public class RiemannInputPlugin implements InputPlugin {
 
     @JsonCreator
     public RiemannInputPlugin(
-        @JsonProperty("protocol") ProtocolFactory protocol, @JsonProperty("retry") RetryPolicy retry
+        @JsonProperty("protocol") ProtocolFactory protocol,
+        @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter
     ) {
         this.protocol = Optional
             .ofNullable(protocol)
@@ -86,10 +88,5 @@ public class RiemannInputPlugin implements InputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return String.format("%s[%s]", getClass().getPackage().getName(), protocol.toString());
     }
 }

--- a/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
+++ b/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
@@ -20,9 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
-import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.filter.TrueFilter;
 import com.spotify.ffwd.output.BatchedPluginSink;
 import com.spotify.ffwd.output.FlushingPluginSink;
 import com.spotify.ffwd.output.OutputPlugin;
@@ -36,25 +34,22 @@ import com.spotify.ffwd.protocol.ProtocolType;
 import com.spotify.ffwd.protocol.RetryPolicy;
 import java.util.Optional;
 
-public class RiemannOutputPlugin implements OutputPlugin {
+public class RiemannOutputPlugin extends OutputPlugin {
     private static final ProtocolType DEFAULT_PROTOCOL = ProtocolType.TCP;
     private static final int DEFAULT_PORT = 5555;
-    private static final long DEFAULT_FLUSH_INTERVAL = 0;
-    // TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS);
 
-    private final Filter filter;
-    private final Long flushInterval;
     private final Protocol protocol;
     private final Class<? extends ProtocolClient> protocolClient;
     private final RetryPolicy retry;
 
     @JsonCreator
     public RiemannOutputPlugin(
-        @JsonProperty("filter") Filter filter, @JsonProperty("flushInterval") Long flushInterval,
-        @JsonProperty("protocol") ProtocolFactory protocol, @JsonProperty("retry") RetryPolicy retry
+        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("protocol") ProtocolFactory protocol,
+        @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter
+
     ) {
-        this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
-        this.flushInterval = Optional.ofNullable(flushInterval).orElse(DEFAULT_FLUSH_INTERVAL);
+        super(filter, flushInterval);
         this.protocol = Optional
             .ofNullable(protocol)
             .orElseGet(ProtocolFactory.defaultFor())
@@ -80,22 +75,18 @@ public class RiemannOutputPlugin implements OutputPlugin {
                 bind(RiemannMessageDecoder.class).in(Scopes.SINGLETON);
                 bind(ProtocolClient.class).to(protocolClient).in(Scopes.SINGLETON);
 
-                if (flushInterval != null && flushInterval > 0) {
-                    bind(Key.get(Filter.class, Names.named("flushing"))).toInstance(filter);
+                if (flushInterval != null && flushInterval.isPresent()) {
                     bind(BatchedPluginSink.class).toInstance(new ProtocolPluginSink(retry));
-                    bind(key).toInstance(new FlushingPluginSink(flushInterval));
+                    bind(key).toInstance(new FlushingPluginSink(flushInterval.get()));
                 } else {
-                    bind(Filter.class).toInstance(filter);
                     bind(key).toInstance(new ProtocolPluginSink(retry));
+                }
+                if (filter != null && filter.isPresent()) {
+                    bind(Filter.class).toInstance(filter.get());
                 }
 
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return protocol.toString();
     }
 }

--- a/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
+++ b/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
+import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.PluginSink;
 import com.spotify.ffwd.protocol.Protocol;
@@ -32,7 +33,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TemplateOutputPlugin implements OutputPlugin {
+public class TemplateOutputPlugin extends OutputPlugin {
     private static final ProtocolType DEFAULT_PROTOCOL = ProtocolType.TCP;
     private static final int DEFAULT_PORT = 8910;
 
@@ -42,8 +43,11 @@ public class TemplateOutputPlugin implements OutputPlugin {
     @JsonCreator
     public TemplateOutputPlugin(
         @JsonProperty("protocol") final ProtocolFactory protocol,
-        @JsonProperty("retry") final RetryPolicy retry
+        @JsonProperty("retry") final RetryPolicy retry,
+        @JsonProperty("filter") Optional<Filter> filter,
+        @JsonProperty("flushInterval") Optional<Long> flushInterval
     ) {
+        super(filter, flushInterval);
         this.protocol = Optional
             .ofNullable(protocol)
             .orElseGet(ProtocolFactory.defaultFor())
@@ -65,10 +69,5 @@ public class TemplateOutputPlugin implements OutputPlugin {
                 expose(key);
             }
         };
-    }
-
-    @Override
-    public String id(int index) {
-        return protocol.toString();
     }
 }


### PR DESCRIPTION
Proposed change makes possible to specify per-plugin filter for ffwd output. Following output plugins were patched and smoke tested: signalfx, http, debug. 

In future we should patch all remaining output plugins and all input plugins.