### PR TITLE
Ffwd http lib: Improvements

### DIFF
--- a/ffwd-http-client/pom.xml
+++ b/ffwd-http-client/pom.xml
@@ -91,6 +91,7 @@
                 <excludes>
                   <exclude>com.google.code.findbugs:annotations</exclude>
                   <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>io.reactivex:rxjava</exclude>
                 </excludes>
               </artifactSet>
 
@@ -123,10 +124,6 @@
                 <relocation>
                   <pattern>org.xbill</pattern>
                   <shadedPattern>com.spotify.ffwd.http.xbill</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>rx</pattern>
-                  <shadedPattern>com.spotify.ffwd.http.rx</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>

--- a/ffwd-http-client/src/main/java/com/spotify/ffwd/http/HttpDiscovery.java
+++ b/ffwd-http-client/src/main/java/com/spotify/ffwd/http/HttpDiscovery.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013-2017 Spotify AB. All rights reserved.
- *
+ * <p>
  * The contents of this file are licensed under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -96,6 +96,9 @@ public interface HttpDiscovery {
         }
 
         public HostAndPort withOptionalSearchDomain(final Optional<String> searchDomain) {
+            if (host.equals("localhost") || host.endsWith(".")) {
+                return this;
+            }
             return searchDomain.map(s -> new HostAndPort(host + "." + s, port)).orElse(this);
         }
     }

--- a/ffwd-http-client/src/main/java/com/spotify/ffwd/http/HttpDiscovery.java
+++ b/ffwd-http-client/src/main/java/com/spotify/ffwd/http/HttpDiscovery.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2013-2017 Spotify AB. All rights reserved.
- * <p>
+ *
  * The contents of this file are licensed under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the


### PR DESCRIPTION
1. Not use search domain with localhost or hostname ending with '.'
2. Exclude shading of io.reactivex:rxjava