### PR TITLE
 [http] close response and propagate errors in modules/http

### DIFF
--- a/ffwd-http-client/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
+++ b/ffwd-http-client/src/main/java/com/spotify/ffwd/http/RawHttpClient.java
@@ -85,6 +85,8 @@ public class RawHttpClient {
                                 "HTTP request failed: " + response.code() + ": " +
                                     response.message()));
                         }
+
+                        response.close();
                     }
                 });
             }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpClient.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpClient.java
@@ -78,7 +78,14 @@ public class HttpClient {
 
             @Override
             public void onResponse(final Call call, final Response response) throws IOException {
-                future.resolve(null);
+                if (response.isSuccessful()) {
+                    future.resolve(null);
+                } else {
+                    future.fail(new RuntimeException(
+                        "HTTP request failed: " + response.code() + ": " + response.message()));
+                }
+
+                response.close();
             }
         });
 


### PR DESCRIPTION
This (hopefully) fixes an issue reported by @mattnworb:
```
WARNING: A connection to <url> was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```
Note: The client code in this module will soon be replaced with [ffwd-http-client](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.spotify.ffwd%22%20AND%20a%3A%22ffwd-http-client%22) which is a cleanup and extraction of the code in the HTTP module that can also be used by third party projects.