### PR TITLE
[core] normalize ffwd_tag environment variables

### DIFF
--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -162,7 +162,7 @@ public class OutputManagerModule {
         for (final Map.Entry<String, String> e : env.entrySet()) {
             if (e.getKey().startsWith(FFWD_TAG_PREFIX)) {
                 final String tag = e.getKey().substring(FFWD_TAG_PREFIX.length());
-                tags.put(tag, e.getValue());
+                tags.put(tag.toLowerCase(), e.getValue());
             }
         }
 

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerModuleTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerModuleTest.java
@@ -14,7 +14,7 @@ public class OutputManagerModuleTest {
     @Test
     public void testFilterEnvironment() {
         final Map<String, String> out = OutputManagerModule.filterEnvironmentTags(
-            ImmutableMap.of("FFWD_TAG_foo", "bar", "PATH", "ignored:ignored", "FFWD_TAG_bar",
+            ImmutableMap.of("FFWD_TAG_FOO", "bar", "PATH", "ignored:ignored", "FFWD_TAG_bar",
                 "baz"));
 
         assertEquals(ImmutableMap.of("foo", "bar", "bar", "baz"), out);

--- a/tools/k8s-shim
+++ b/tools/k8s-shim
@@ -39,7 +39,7 @@ cat <<ENDL
 - name: ffwd-java-shim
   image: $tag
   env:
-  - name: FFWD_TAG_podname
+  - name: FFWD_TAG_PODNAME
     valueFrom:
       fieldRef:
         fieldPath: metadata.name


### PR DESCRIPTION
It is general convention that environment variables are capitalized.

Rather than exporting an environment variable as `FFWD_TAG_foo` and knowing `foo` should
be lowercase, this change proposes normalizing all parsed tags to be lowercased. 

With this change `FFWD_TAG_FOO` and `FFWD_TAG_foo` will produce the same tag and be part of the same timeseries.

Thoughts? @udoprog @mattnworb @nezdolik 