### PR TITLE
[all] support resource identifiers in Batch

### DIFF
--- a/agent/ffwd-local-debug.yaml
+++ b/agent/ffwd-local-debug.yaml
@@ -21,7 +21,6 @@ input:
     - type: http
       protocol:
         type: tcp
-        port: 12345
 
 output:
   plugins:

--- a/api/src/main/java/com/spotify/ffwd/Mappers.java
+++ b/api/src/main/java/com/spotify/ffwd/Mappers.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 public class Mappers {
     public static ObjectMapper setupApplicationJson() {
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new Jdk8Module());
-        mapper.enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
-        mapper.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
-        return mapper;
+        final ObjectMapper m = new ObjectMapper();
+        m.enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+        m.enable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES);
+        m.registerModule(new Jdk8Module());
+        return m;
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/model/Batch.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Batch.java
@@ -18,42 +18,56 @@ package com.spotify.ffwd.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RequiredArgsConstructor(suppressConstructorProperties = true)
 public class Batch {
     private final Map<String, String> commonTags;
+    private final Map<String, String> commonResource;
     private final List<Point> points;
 
+    /**
+     * JSON creator.
+     */
     @JsonCreator
-    public Batch(
-        @JsonProperty("commonTags") final Map<String, String> commonTags,
+    public static Batch create(
+        @JsonProperty("commonTags") final Optional<Map<String, String>> commonTags,
+        @JsonProperty("commonResource") final Optional<Map<String, String>> commonResource,
         @JsonProperty("points") final List<Point> points
     ) {
-        this.commonTags = commonTags;
-        this.points = points;
+        return new Batch(commonTags.orElseGet(ImmutableMap::of),
+            commonResource.orElseGet(ImmutableMap::of), points);
     }
 
     @Data
+    @RequiredArgsConstructor(suppressConstructorProperties = true)
     public static class Point {
         private final String key;
         private final Map<String, String> tags;
+        private final Map<String, String> resource;
         private final double value;
         private final long timestamp;
 
-        public Point(
+        /**
+         * JSON creator.
+         */
+        @JsonCreator
+        public static Point create(
             @JsonProperty("key") final String key,
-            @JsonProperty("tags") final Map<String, String> tags,
+            @JsonProperty("tags") final Optional<Map<String, String>> tags,
+            @JsonProperty("resource") final Optional<Map<String, String>> resource,
             @JsonProperty("value") final double value,
             @JsonProperty("timestamp") final long timestamp
         ) {
-            this.key = key;
-            this.tags = tags;
-            this.value = value;
-            this.timestamp = timestamp;
+            return new Point(key, tags.orElseGet(ImmutableMap::of),
+                resource.orElseGet(ImmutableMap::of), value, timestamp);
         }
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/model/Metric.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Metric.java
@@ -33,6 +33,7 @@ public class Metric {
     private final String host;
     private final Set<String> riemannTags;
     private final Map<String, String> tags;
+    private final Map<String, String> resource;
     private final String proc;
 
     /**
@@ -41,6 +42,6 @@ public class Metric {
      * @return a batch point
      */
     public Batch.Point toBatchPoint() {
-        return new Batch.Point(key, tags, value, time.getTime());
+        return new Batch.Point(key, tags, resource, value, time.getTime());
     }
 }

--- a/api/src/test/java/com/spotify/ffwd/model/TestBatch.java
+++ b/api/src/test/java/com/spotify/ffwd/model/TestBatch.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestBatch {
-
     private ObjectMapper mapper;
 
     @Before
@@ -26,6 +25,12 @@ public class TestBatch {
     @Test
     public void testBatch1() throws Exception {
         final String value = readResources("TestBatch.1.json");
+        mapper.readValue(value, Batch.class);
+    }
+
+    @Test
+    public void testBatchWithResource() throws Exception {
+        final String value = readResources("TestBatch.WithResource.json");
         mapper.readValue(value, Batch.class);
     }
 

--- a/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
@@ -40,11 +40,12 @@ public class FilteringPluginSinkTest {
         sink = spy(new FilteringPluginSink(new TrueFilter()));
         sink.sink = childSink;
         metric = new Metric("test_metric", 1278, new Date(), "", ImmutableSet.of(),
-            ImmutableMap.of("what", "stats", "pod", "gew1"), "test_proc");
+            ImmutableMap.of("what", "stats", "pod", "gew1"), ImmutableMap.of(), "test_proc");
         event =
             new Event("test_event", 1278, new Date(), 12L, "critical", "test_event", "test_host",
                 ImmutableSet.of(), ImmutableMap.of("what", "stats", "pod", "gew1"));
-        batch = new Batch(ImmutableMap.of("what", "stats", "pod", "gew1"), ImmutableList.of());
+        batch = new Batch(ImmutableMap.of("what", "stats", "pod", "gew1"), ImmutableMap.of(),
+            ImmutableList.of());
     }
 
     @Test

--- a/api/src/test/resources/TestBatch.WithResource.json
+++ b/api/src/test/resources/TestBatch.WithResource.json
@@ -1,0 +1,35 @@
+{
+  "commonTags": {
+    "host": "database.example.com"
+  },
+  "commonResource": {
+    "node": "foobar"
+  },
+  "points": [
+    {
+      "key": "system",
+      "tags": {
+        "what": "cpu-used-percentage",
+        "unit": "%"
+      },
+      "resource": {
+        "instance": "hello1"
+      },
+      "value": 0.42,
+      "timestamp": 1508508795000
+    },
+    {
+      "key": "system",
+      "tags": {
+        "what": "disk-used-bytes",
+        "unit": "B",
+        "disk_name": "/dev/sda"
+      },
+      "resource": {
+        "instance": "hello2"
+      },
+      "value": 42000000000,
+      "timestamp": 1508508795000
+    }
+  ]
+}

--- a/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
+++ b/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
@@ -90,9 +90,10 @@ public class GeneratedPluginSource implements PluginSource {
             final String host = generateHost(i);
             final Set<String> riemannTags = ImmutableSet.of();
             final Map<String, String> tags = ImmutableMap.of("what", "metric-" + i);
+            final Map<String, String> resource = ImmutableMap.of();
             final String proc = null;
 
-            metrics.add(new Metric(key, value, time, host, riemannTags, tags, proc));
+            metrics.add(new Metric(key, value, time, host, riemannTags, tags, resource, proc));
         }
 
         return metrics;

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -196,7 +196,7 @@ public class CoreOutputManager implements OutputManager {
         mergedRiemannTags.addAll(metric.getRiemannTags());
 
         return new Metric(metric.getKey(), metric.getValue(), time, host, mergedRiemannTags,
-            mergedTags, metric.getProc());
+            mergedTags, metric.getResource(), metric.getProc());
     }
 
     /**
@@ -204,13 +204,13 @@ public class CoreOutputManager implements OutputManager {
      */
     private Batch filter(final Batch batch) {
         if (batch.getCommonTags().isEmpty()) {
-            return new Batch(tags, batch.getPoints());
+            return new Batch(tags, batch.getCommonResource(), batch.getPoints());
         }
 
         final Map<String, String> commonTags;
         commonTags = new HashMap<>(this.tags);
         commonTags.putAll(tags);
-        return new Batch(commonTags, batch.getPoints());
+        return new Batch(commonTags, batch.getCommonResource(), batch.getPoints());
     }
 
     private Map<String, String> selectTags(Metric metric) {

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
@@ -22,13 +22,12 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import lombok.Data;
 
 @JsonTypeName("spotify100")
 public class Spotify100Serializer implements Serializer {
-    public static final String SCHEMA_VERSION = "1.0.0";
+    public static final String SCHEMA_VERSION = "1.1.0";
 
     @Inject
     @Named("application/json")
@@ -41,6 +40,7 @@ public class Spotify100Serializer implements Serializer {
         private final String host;
         private final Long time;
         private final Map<String, String> attributes;
+        private final Map<String, String> resource;
         private final Double value;
     }
 
@@ -63,19 +63,15 @@ public class Spotify100Serializer implements Serializer {
         final Spotify100Event e =
             new Spotify100Event(source.getKey(), source.getHost(), source.getTime().getTime(),
                 source.getTags(), source.getValue());
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        mapper.writeValue(outputStream, e);
-        return outputStream.toByteArray();
+        return mapper.writeValueAsBytes(e);
     }
 
     @Override
     public byte[] serialize(Metric source) throws Exception {
         final Spotify100Metric m =
             new Spotify100Metric(source.getKey(), source.getHost(), source.getTime().getTime(),
-                source.getTags(), source.getValue());
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        mapper.writeValue(outputStream, m);
-        return outputStream.toByteArray();
+                source.getTags(), source.getResource(), source.getValue());
+        return mapper.writeValueAsBytes(m);
     }
 }
 

--- a/modules/carbon/src/main/java/com/spotify/ffwd/carbon/CarbonDecoder.java
+++ b/modules/carbon/src/main/java/com/spotify/ffwd/carbon/CarbonDecoder.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.ffwd.carbon;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.spotify.ffwd.model.Metric;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -32,6 +33,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 @Sharable
 public class CarbonDecoder extends MessageToMessageDecoder<String> {
     private static final Set<String> EMPTY_TAGS = Sets.newHashSet();
+    private static final Map<String, String> EMPTY_RESOURCE = ImmutableMap.of();
     private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile("\\s+");
 
     private final String key;
@@ -72,6 +74,7 @@ public class CarbonDecoder extends MessageToMessageDecoder<String> {
         final Map<String, String> tags = new HashMap<>();
         tags.put("what", tokens[0]);
 
-        out.add(new Metric(key, value, new Date(timestamp), null, EMPTY_TAGS, tags, null));
+        out.add(new Metric(key, value, new Date(timestamp), null, EMPTY_TAGS, tags, EMPTY_RESOURCE,
+            null));
     }
 }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
@@ -107,7 +107,7 @@ public class HttpPluginSink implements BatchedPluginSink {
         }
 
         // creates a new batch _without_ common tags, prefer using sendBatches instead.
-        final Batch b = new Batch(ImmutableMap.of(), out);
+        final Batch b = new Batch(ImmutableMap.of(), ImmutableMap.of(), out);
 
         return sendBatches(ImmutableList.of(b));
     }

--- a/modules/json/src/main/java/com/spotify/ffwd/json/JsonObjectMapperDecoder.java
+++ b/modules/json/src/main/java/com/spotify/ffwd/json/JsonObjectMapperDecoder.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -106,9 +107,11 @@ public class JsonObjectMapperDecoder extends MessageToMessageDecoder<ByteBuf> {
         final String host = decodeString(tree, "host");
         final Set<String> riemannTags = decodeTags(tree, "tags");
         final Map<String, String> tags = decodeAttributes(tree, "attributes");
+        // TODO: support resource?
+        final Map<String, String> resource = ImmutableMap.of();
         final String proc = decodeString(tree, "proc");
 
-        return new Metric(key, value, time, host, riemannTags, tags, proc);
+        return new Metric(key, value, time, host, riemannTags, tags, resource, proc);
     }
 
     private Object decodeEvent(JsonNode tree, List<Object> out) {

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
@@ -109,15 +109,18 @@ public class KafkaPluginSink implements BatchedPluginSink {
     private KeyedMessage<Integer, byte[]> convertBatchMetric(
         final Batch batch, final Batch.Point point
     ) throws Exception {
-        final Map<String, String> allTags = new HashMap<>();
-        allTags.putAll(batch.getCommonTags());
+        final Map<String, String> allTags = new HashMap<>(batch.getCommonTags());
         allTags.putAll(point.getTags());
+
+        final Map<String, String> allResource = new HashMap<>(batch.getCommonResource());
+        allResource.putAll(point.getResource());
 
         final String host = allTags.remove("host");
 
+        // TODO: support serialization of batches more... immediately.
         return metricConverter.toMessage(
             new Metric(point.getKey(), point.getValue(), new Date(point.getTimestamp()), host,
-                ImmutableSet.of(), allTags, null));
+                ImmutableSet.of(), allTags, allResource, null));
     }
 
     @Override

--- a/modules/protobuf/src/main/java/com/spotify/ffwd/protobuf/ProtobufDecoder.java
+++ b/modules/protobuf/src/main/java/com/spotify/ffwd/protobuf/ProtobufDecoder.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.ffwd.protobuf;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf250.InvalidProtocolBufferException;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
@@ -119,9 +120,11 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
         final String host = metric.hasHost() ? metric.getHost() : null;
         final Set<String> riemannTags = new HashSet<>(metric.getTagsList());
         final Map<String, String> tags = convertAttributes0(metric.getAttributesList());
+        // TODO: support resource identifiers.
+        final Map<String, String> resource = ImmutableMap.of();
         final String proc = metric.hasProc() ? metric.getProc() : null;
 
-        return new Metric(key, value, time, host, riemannTags, tags, proc);
+        return new Metric(key, value, time, host, riemannTags, tags, resource, proc);
     }
 
     private Map<String, String> convertAttributes0(List<Protocol0.Attribute> attributesList) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <tiny-async.version>1.11.0</tiny-async.version>
     <log4j.version>2.2</log4j.version>
     <slf4j.version>1.7.10</slf4j.version>
-    <jackson.version>2.7.4</jackson.version>
+    <jackson.version>2.9.3</jackson.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Jackson upgrade needed because the needed DeserializationFeatures were not supported in the version used.