### PR TITLE
Fix flushInterval breakage

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/output/FilteringDelegate.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FilteringDelegate.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.output;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@BindingAnnotation
+public @interface FilteringDelegate {
+}

--- a/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class FilteringPluginSink implements PluginSink {
     @Inject
+    @FilteringDelegate
     protected PluginSink sink;
 
     protected Filter filter;

--- a/api/src/main/java/com/spotify/ffwd/output/FlushingDelegate.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FlushingDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Spotify AB. All rights reserved.
+ * Copyright 2018 Spotify AB. All rights reserved.
  *
  * The contents of this file are licensed under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with the
@@ -15,20 +15,14 @@
  */
 package com.spotify.ffwd.output;
 
-import com.google.inject.Key;
-import com.google.inject.PrivateModule;
-import lombok.Data;
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@Data
-public class OutputDelegatingModule<T extends PluginSink> extends PrivateModule {
-    private final Key<PluginSink> input;
-    private final Key<PluginSink> output;
-    private final T impl;
-
-    @Override
-    protected void configure() {
-        bind(input.getTypeLiteral()).to(input);
-        bind(output).toInstance(impl);
-        expose(output);
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@BindingAnnotation
+public @interface FlushingDelegate {
 }

--- a/api/src/main/java/com/spotify/ffwd/output/FlushingPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FlushingPluginSink.java
@@ -57,6 +57,7 @@ public class FlushingPluginSink implements PluginSink {
     AsyncFramework async;
 
     @Inject
+    @FlushingDelegate
     BatchedPluginSink sink;
 
     @Inject

--- a/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
@@ -21,7 +21,6 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.output.BatchedPluginSink;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -47,13 +46,12 @@ public class DebugOutputPlugin extends OutputPlugin {
         return new OutputPluginModule(id) {
             @Override
             protected void configure() {
-                bind(BatchedPluginSink.class).to(DebugPluginSink.class);
-                Key<PluginSink> sinkKey = Key.get(PluginSink.class, Names.named("debugSinkSink"));
+                final Key<DebugPluginSink> sinkKey =
+                    Key.get(DebugPluginSink.class, Names.named("debugSink"));
                 bind(sinkKey).to(DebugPluginSink.class);
                 install(wrapPluginSink(sinkKey, key));
                 expose(key);
             }
         };
     }
-
 }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpOutputPlugin.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpOutputPlugin.java
@@ -27,7 +27,6 @@ import com.google.inject.name.Names;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.LoadBalancerBuilder;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.output.BatchedPluginSink;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -78,8 +77,8 @@ public class HttpOutputPlugin extends OutputPlugin {
 
             @Override
             protected void configure() {
-                bind(BatchedPluginSink.class).to(HttpPluginSink.class);
-                Key<PluginSink> sinkKey = Key.get(PluginSink.class, Names.named("httpSink"));
+                final Key<HttpPluginSink> sinkKey =
+                    Key.get(HttpPluginSink.class, Names.named("httpSink"));
                 bind(sinkKey).to(HttpPluginSink.class);
                 install(wrapPluginSink(sinkKey, key));
                 expose(key);

--- a/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxOutputPlugin.java
+++ b/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxOutputPlugin.java
@@ -31,7 +31,6 @@ import com.signalfx.metrics.connection.HttpEventProtobufReceiverFactory;
 import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
 import com.signalfx.metrics.flush.AggregateMetricSender;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.output.BatchedPluginSink;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -54,8 +53,7 @@ public class SignalFxOutputPlugin extends OutputPlugin {
 
     @JsonCreator
     public SignalFxOutputPlugin(
-        @JsonProperty("sourceName") String sourceName,
-        @JsonProperty("authToken") String authToken,
+        @JsonProperty("sourceName") String sourceName, @JsonProperty("authToken") String authToken,
         @JsonProperty("flushInterval") Optional<Long> flushInterval,
         @JsonProperty("soTimeout") Integer soTimeout,
         @JsonProperty("filter") Optional<Filter> filter
@@ -103,8 +101,8 @@ public class SignalFxOutputPlugin extends OutputPlugin {
 
             @Override
             protected void configure() {
-                bind(BatchedPluginSink.class).to(SignalFxPluginSink.class);
-                Key<PluginSink> sinkKey = Key.get(PluginSink.class, Names.named("signalfxSink"));
+                final Key<SignalFxPluginSink> sinkKey =
+                    Key.get(SignalFxPluginSink.class, Names.named("signalfxSink"));
                 bind(sinkKey).to(SignalFxPluginSink.class);
                 install(wrapPluginSink(sinkKey, key));
                 expose(key);


### PR DESCRIPTION
flushInterval was ignored for http, debug and signalfx outputs. I.e. no auto-batching of metrics is performed.