### PR TITLE
[all] Introduce 'batching' conf for outputs

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/module/Batching.java
+++ b/api/src/main/java/com/spotify/ffwd/module/Batching.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.module;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+import lombok.Data;
+
+@Data
+public class Batching {
+    protected final Optional<Long> flushInterval;
+    protected final Optional<Long> batchSizeLimit;
+    protected final Optional<Long> maxPendingFlushes;
+
+    @JsonCreator
+    public Batching(
+        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("batchSizeLimit") Optional<Long> batchSizeLimit,
+        @JsonProperty("maxPendingFlushes") Optional<Long> maxPendingFlushes
+    ) {
+        this.flushInterval = flushInterval;
+        this.batchSizeLimit = batchSizeLimit;
+        this.maxPendingFlushes = maxPendingFlushes;
+    }
+
+    public static Batching empty() {
+        return from(Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public static Batching from(
+        final Optional<Long> flushInterval, final Optional<Batching> batching
+    ) {
+        return from(flushInterval, batching, Optional.empty());
+    }
+
+    public static Batching from(
+        final Optional<Long> flushInterval, final Optional<Batching> batching,
+        final Optional<Long> defaultFlushInterval
+    ) {
+        if (flushInterval.isPresent() && batching.isPresent()) {
+            throw new RuntimeException(
+                "Can't have both 'batching' and 'flushInterval' on the same level in the " +
+                    "configuration. Maybe move 'flushInterval' into 'batching'?");
+        }
+        if (batching.isPresent()) {
+            return batching.get();
+        }
+        if (flushInterval.isPresent()) {
+            return new Batching(flushInterval, Optional.empty(), Optional.empty());
+        }
+        return new Batching(defaultFlushInterval, Optional.empty(), Optional.empty());
+    }
+}

--- a/api/src/main/java/com/spotify/ffwd/module/Batching.java
+++ b/api/src/main/java/com/spotify/ffwd/module/Batching.java
@@ -47,6 +47,23 @@ public class Batching {
         return from(flushInterval, batching, Optional.empty());
     }
 
+    /**
+     * This method exists to create a unified interface for configuration batching. This object
+     * hides a compatibility path to the old way of specifying flushInterval (outside of a
+     * 'batching' block).
+     * <p>
+     * BatchingPluginSink can be placed in front of any output plugin. Different output plugins
+     * might use different configuration for their batching. This class contains all configuration
+     * for batching, and may be specified for every output plugin.
+     *
+     * @param flushInterval Optional configuration on the output plugin level in the configuration.
+     * This only contains something when the user didn't use any 'batching' sub structure in the
+     * configuration, and just specified flushInterval.
+     * @param batching A complete Batching structure, on the output plugin level in the conf.
+     * @param defaultFlushInterval Optional default value to be used if no flushInterval nor
+     * batching was specified.
+     * @return A Batching object.
+     */
     public static Batching from(
         final Optional<Long> flushInterval, final Optional<Batching> batching,
         final Optional<Long> defaultFlushInterval

--- a/api/src/main/java/com/spotify/ffwd/output/BatchablePluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/BatchablePluginSink.java
@@ -21,7 +21,7 @@ import com.spotify.ffwd.model.Metric;
 import eu.toolchain.async.AsyncFuture;
 import java.util.Collection;
 
-public interface BatchedPluginSink extends PluginSink {
+public interface BatchablePluginSink extends PluginSink {
     /**
      * Send the given collection of events.
      *

--- a/api/src/main/java/com/spotify/ffwd/output/BatchingDelegate.java
+++ b/api/src/main/java/com/spotify/ffwd/output/BatchingDelegate.java
@@ -24,5 +24,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @BindingAnnotation
-public @interface FlushingDelegate {
+public @interface BatchingDelegate {
 }

--- a/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/FilteringPluginSink.java
@@ -21,12 +21,15 @@ import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import eu.toolchain.async.AsyncFuture;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class FilteringPluginSink implements PluginSink {
+
     @Inject
     @FilteringDelegate
+    @Getter
     protected PluginSink sink;
 
     protected Filter filter;

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
@@ -23,24 +23,31 @@ import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.module.Batching;
 import java.util.Optional;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
 public abstract class OutputPlugin {
 
-    protected final Optional<Long> flushInterval;
+    protected final Batching batching;
     protected final Optional<Filter> filter;
 
     public OutputPlugin() {
         filter = Optional.empty();
-        flushInterval = Optional.empty();
+        batching = Batching.empty();
     }
 
     public OutputPlugin(
-        final Optional<Filter> filter, final Optional<Long> flushInterval
+        final Optional<Filter> filter, final Batching batching
     ) {
         this.filter = filter;
-        this.flushInterval = flushInterval;
+        this.batching = batching;
+        if (filter == null) {
+            throw new RuntimeException("filter can't be null");
+        }
+        if (batching == null) {
+            throw new RuntimeException("batching can't be null");
+        }
     }
 
     /**
@@ -62,35 +69,38 @@ public abstract class OutputPlugin {
      * <code>output := new FilteringPluginSink(filter, delegator:=output)</code>
      *
      * @param input binding key with injection type of plugin sink
-     * @param output binding key, containing injection type of wrapping plugin sink
+     * @param wrapKey binding key, containing injection type of wrapping plugin sink
      * @return module that exposes output binding key
      */
     protected Module wrapPluginSink(
-        final Key<? extends PluginSink> input, final Key<PluginSink> output
+        final Key<? extends PluginSink> input, final Key<PluginSink> wrapKey
     ) {
         return new PrivateModule() {
             @Override
             protected void configure() {
                 Key<PluginSink> sinkKey = (Key<PluginSink>) input;
 
-                if (flushInterval != null && flushInterval.isPresent() &&
-                    BatchedPluginSink.class.isAssignableFrom(
-                        sinkKey.getTypeLiteral().getRawType())) {
+                if (batching.getFlushInterval().isPresent() &&
+                    BatchablePluginSink.class.isAssignableFrom(
+                        input.getTypeLiteral().getRawType())) {
                     final Key<PluginSink> flushingKey =
                         Key.get(PluginSink.class, Names.named("flushing"));
-                    final Key<? extends BatchedPluginSink> batchedPluginSink =
-                        (Key<? extends BatchedPluginSink>) (Key<? extends PluginSink>) sinkKey;
+                    // IDEA doesn't like this cast, but it's correct, tho admittedly not pretty
+                    final Key<? extends BatchablePluginSink> batchedPluginSink =
+                        (Key<? extends BatchablePluginSink>) (Key<? extends PluginSink>) sinkKey;
 
                     // Use annotation so that we can avoid name space clash
-                    bind(BatchedPluginSink.class)
-                        .annotatedWith(FlushingDelegate.class)
+                    bind(BatchablePluginSink.class)
+                        .annotatedWith(BatchingDelegate.class)
                         .to(batchedPluginSink);
-                    bind(flushingKey).toInstance(new FlushingPluginSink(flushInterval.get()));
+                    bind(flushingKey).toInstance(
+                        new BatchingPluginSink(batching.getFlushInterval().get(),
+                            batching.getBatchSizeLimit(), batching.getMaxPendingFlushes()));
 
                     sinkKey = flushingKey;
                 }
 
-                if (filter != null && filter.isPresent()) {
+                if (filter.isPresent()) {
                     final Key<PluginSink> filteringKey =
                         Key.get(PluginSink.class, Names.named("filtered"));
 
@@ -101,8 +111,8 @@ public abstract class OutputPlugin {
                     sinkKey = filteringKey;
                 }
 
-                bind(output).to(sinkKey);
-                expose(output);
+                bind(wrapKey).to(sinkKey);
+                expose(wrapKey);
             }
         };
     }

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
@@ -32,22 +32,11 @@ public abstract class OutputPlugin {
     protected final Batching batching;
     protected final Optional<Filter> filter;
 
-    public OutputPlugin() {
-        filter = Optional.empty();
-        batching = Batching.empty();
-    }
-
     public OutputPlugin(
         final Optional<Filter> filter, final Batching batching
     ) {
         this.filter = filter;
         this.batching = batching;
-        if (filter == null) {
-            throw new RuntimeException("filter can't be null");
-        }
-        if (batching == null) {
-            throw new RuntimeException("batching can't be null");
-        }
     }
 
     /**

--- a/api/src/main/java/com/spotify/ffwd/protocol/ProtocolPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/protocol/ProtocolPluginSink.java
@@ -22,7 +22,7 @@ import com.spotify.ffwd.filter.TrueFilter;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.LazyTransform;
@@ -32,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 
 @RequiredArgsConstructor
-public class ProtocolPluginSink implements BatchedPluginSink {
+public class ProtocolPluginSink implements BatchablePluginSink {
     @Inject
     private AsyncFramework async;
 

--- a/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkIntegrationTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkIntegrationTest.java
@@ -45,11 +45,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FlushingPluginSinkIntegrationTest {
+public class BatchingPluginSinkIntegrationTest {
     private static final int BATCH_SIZE = 1000;
 
     @Mock
-    private BatchedPluginSink childSink;
+    private BatchablePluginSink childSink;
 
     @Mock
     private Metric metric;
@@ -60,7 +60,7 @@ public class FlushingPluginSinkIntegrationTest {
     @Captor
     private ArgumentCaptor<Collection<Metric>> metricsCaptor;
 
-    private FlushingPluginSink sink;
+    private BatchingPluginSink sink;
     private AsyncFramework async;
 
     private final ExecutorService executor =
@@ -69,7 +69,7 @@ public class FlushingPluginSinkIntegrationTest {
     @Before
     public void setup() {
         // flush every second, limiting the batch sizes to 1000, with 5 max pending flushes.
-        sink = new FlushingPluginSink(0, BATCH_SIZE, 0);
+        sink = new BatchingPluginSink(0, BATCH_SIZE, 0);
         async = TinyAsync.builder().executor(executor).build();
 
         doReturn(async.resolved()).when(childSink).start();

--- a/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import eu.toolchain.async.AsyncFramework;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 
 @RunWith(MockitoJUnitRunner.class)
-public class FlushingPluginSinkTest {
+public class BatchingPluginSinkTest {
     private final long flushInterval = 1000;
     private final long batchSizeLimit = 2000;
     private final long maxPendingFlushes = 3000;
@@ -43,7 +44,7 @@ public class FlushingPluginSinkTest {
     private AsyncFramework async;
 
     @Mock
-    private BatchedPluginSink childSink;
+    private BatchablePluginSink childSink;
 
     @Mock
     private Metric metric;
@@ -52,7 +53,7 @@ public class FlushingPluginSinkTest {
     private Event event;
 
     @Mock
-    private FlushingPluginSink.Batch batch;
+    private BatchingPluginSink.Batch batch;
 
     @Mock
     private Logger log;
@@ -60,11 +61,11 @@ public class FlushingPluginSinkTest {
     @Mock
     private ScheduledExecutorService scheduler;
 
-    private FlushingPluginSink sink;
+    private BatchingPluginSink sink;
 
     @Before
     public void setup() {
-        sink = spy(new FlushingPluginSink(flushInterval, batchSizeLimit, maxPendingFlushes));
+        sink = spy(new BatchingPluginSink(flushInterval, batchSizeLimit, maxPendingFlushes));
         sink.sink = childSink;
         sink.async = async;
         sink.log = log;
@@ -73,11 +74,11 @@ public class FlushingPluginSinkTest {
 
     @Test
     public void testDefaultConstructor() {
-        final FlushingPluginSink s = new FlushingPluginSink(1);
+        final BatchingPluginSink s = new BatchingPluginSink(1, Optional.empty(), Optional.empty());
 
         assertEquals(1, s.flushInterval);
-        assertEquals(FlushingPluginSink.DEFAULT_BATCH_SIZE_LIMIT, s.batchSizeLimit);
-        assertEquals(FlushingPluginSink.DEFAULT_MAX_PENDING_FLUSHES, s.maxPendingFlushes);
+        assertEquals(BatchingPluginSink.DEFAULT_BATCH_SIZE_LIMIT, s.batchSizeLimit);
+        assertEquals(BatchingPluginSink.DEFAULT_MAX_PENDING_FLUSHES, s.maxPendingFlushes);
     }
 
     @Test

--- a/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/FilteringPluginSinkTest.java
@@ -28,7 +28,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class FilteringPluginSinkTest {
 
     @Mock
-    private FlushingPluginSink childSink;
+    private BatchingPluginSink childSink;
     private FilteringPluginSink sink;
 
     private Metric metric;

--- a/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
@@ -19,8 +19,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.module.Batching;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -35,10 +37,10 @@ public class DebugOutputPlugin extends OutputPlugin {
     @JsonCreator
     public DebugOutputPlugin(
         @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("filter") Optional<Filter> filter
     ) {
-        super(filter,
-            flushInterval.isPresent() ? flushInterval : Optional.of(DEFAULT_FLUSH_INTERVAL));
+        super(filter, Batching.from(flushInterval, batching, Optional.of(DEFAULT_FLUSH_INTERVAL)));
     }
 
     @Override
@@ -48,7 +50,7 @@ public class DebugOutputPlugin extends OutputPlugin {
             protected void configure() {
                 final Key<DebugPluginSink> sinkKey =
                     Key.get(DebugPluginSink.class, Names.named("debugSink"));
-                bind(sinkKey).to(DebugPluginSink.class);
+                bind(sinkKey).to(DebugPluginSink.class).in(Scopes.SINGLETON);
                 install(wrapPluginSink(sinkKey, key));
                 expose(key);
             }

--- a/core/src/main/java/com/spotify/ffwd/debug/DebugPluginSink.java
+++ b/core/src/main/java/com/spotify/ffwd/debug/DebugPluginSink.java
@@ -19,14 +19,14 @@ import com.google.inject.Inject;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import java.util.Collection;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class DebugPluginSink implements BatchedPluginSink {
+public class DebugPluginSink implements BatchablePluginSink {
     @Inject
     private AsyncFramework async;
 

--- a/core/src/main/java/com/spotify/ffwd/noop/NoopPluginSink.java
+++ b/core/src/main/java/com/spotify/ffwd/noop/NoopPluginSink.java
@@ -19,7 +19,7 @@ import com.google.inject.Inject;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import java.util.Collection;
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class NoopPluginSink implements BatchedPluginSink {
+public class NoopPluginSink implements BatchablePluginSink {
     private final AtomicLong date = new AtomicLong();
     private final AtomicLong last = new AtomicLong();
     private final AtomicLong total = new AtomicLong();

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -40,6 +41,7 @@ public class CoreOutputManager implements OutputManager {
     private static final String DEBUG_ID = "core.output";
 
     @Inject
+    @Getter
     private List<PluginSink> sinks;
 
     @Inject

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
@@ -22,7 +22,7 @@ import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.FutureDone;
@@ -39,7 +39,7 @@ import rx.Observable;
 import rx.Observer;
 
 @Slf4j
-public class HttpPluginSink implements BatchedPluginSink {
+public class HttpPluginSink implements BatchablePluginSink {
     public static final StreamCollector<Void, Void> VOID_COLLECTOR =
         new StreamCollector<Void, Void>() {
             @Override

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaOutputPlugin.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaOutputPlugin.java
@@ -23,8 +23,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.output.BatchedPluginSink;
-import com.spotify.ffwd.output.FlushingPluginSink;
+import com.spotify.ffwd.module.Batching;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -51,6 +50,7 @@ public class KafkaOutputPlugin extends OutputPlugin {
     public KafkaOutputPlugin(
         @JsonProperty("producer") Map<String, String> properties,
         @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("router") KafkaRouter router,
         @JsonProperty("partitioner") KafkaPartitioner partitioner,
         @JsonProperty("serializer") Serializer serializer,
@@ -58,7 +58,7 @@ public class KafkaOutputPlugin extends OutputPlugin {
         @JsonProperty("compression") Boolean compression,
         @JsonProperty("filter") Optional<Filter> filter
     ) {
-        super(filter, flushInterval);
+        super(filter, Batching.from(flushInterval, batching));
         this.router = Optional.ofNullable(router).orElseGet(KafkaRouter.Tag.supplier());
         this.partitioner = Optional.ofNullable(partitioner).orElseGet(KafkaPartitioner.Host::new);
         this.properties = Optional.ofNullable(properties).orElseGet(HashMap::new);
@@ -99,16 +99,12 @@ public class KafkaOutputPlugin extends OutputPlugin {
                     bind(Serializer.class).to(Key.get(Serializer.class, Names.named("default")));
                 }
 
-                if (flushInterval.isPresent()) {
-                    bind(BatchedPluginSink.class).toInstance(new KafkaPluginSink(batchSize));
-                    bind(key).toInstance(new FlushingPluginSink(flushInterval.get()));
-                } else {
-                    bind(key).toInstance(new KafkaPluginSink(batchSize));
-                }
-
+                final Key<KafkaPluginSink> sinkKey =
+                    Key.get(KafkaPluginSink.class, Names.named("kafkaSink"));
+                bind(sinkKey).toInstance(new KafkaPluginSink(batchSize));
+                install(wrapPluginSink(sinkKey, key));
                 expose(key);
             }
         };
     }
-
 }

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
@@ -23,7 +23,7 @@ import com.google.inject.Inject;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import com.spotify.ffwd.serializer.Serializer;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
@@ -45,7 +45,7 @@ import kafka.producer.KeyedMessage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class KafkaPluginSink implements BatchedPluginSink {
+public class KafkaPluginSink implements BatchablePluginSink {
     @Inject
     private AsyncFramework async;
 

--- a/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
+++ b/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
@@ -20,9 +20,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
 import com.spotify.ffwd.filter.Filter;
-import com.spotify.ffwd.output.BatchedPluginSink;
-import com.spotify.ffwd.output.FlushingPluginSink;
+import com.spotify.ffwd.module.Batching;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.OutputPluginModule;
 import com.spotify.ffwd.output.PluginSink;
@@ -45,11 +45,12 @@ public class RiemannOutputPlugin extends OutputPlugin {
     @JsonCreator
     public RiemannOutputPlugin(
         @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("protocol") ProtocolFactory protocol,
         @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter
 
     ) {
-        super(filter, flushInterval);
+        super(filter, Batching.from(flushInterval, batching));
         this.protocol = Optional
             .ofNullable(protocol)
             .orElseGet(ProtocolFactory.defaultFor())
@@ -75,15 +76,10 @@ public class RiemannOutputPlugin extends OutputPlugin {
                 bind(RiemannMessageDecoder.class).in(Scopes.SINGLETON);
                 bind(ProtocolClient.class).to(protocolClient).in(Scopes.SINGLETON);
 
-                if (flushInterval != null && flushInterval.isPresent()) {
-                    bind(BatchedPluginSink.class).toInstance(new ProtocolPluginSink(retry));
-                    bind(key).toInstance(new FlushingPluginSink(flushInterval.get()));
-                } else {
-                    bind(key).toInstance(new ProtocolPluginSink(retry));
-                }
-                if (filter != null && filter.isPresent()) {
-                    bind(Filter.class).toInstance(filter.get());
-                }
+                final Key<ProtocolPluginSink> sinkKey =
+                    Key.get(ProtocolPluginSink.class, Names.named("riemannSink"));
+                bind(sinkKey).toInstance(new ProtocolPluginSink(retry));
+                install(wrapPluginSink(sinkKey, key));
 
                 expose(key);
             }

--- a/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxPluginSink.java
+++ b/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxPluginSink.java
@@ -23,7 +23,7 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import com.spotify.ffwd.output.BatchedPluginSink;
+import com.spotify.ffwd.output.BatchablePluginSink;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import eu.toolchain.async.FutureFailed;
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class SignalFxPluginSink implements BatchedPluginSink {
+public class SignalFxPluginSink implements BatchablePluginSink {
     @Inject
     AsyncFramework async;
 

--- a/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
+++ b/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
@@ -21,6 +21,7 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.module.Batching;
 import com.spotify.ffwd.output.OutputPlugin;
 import com.spotify.ffwd.output.PluginSink;
 import com.spotify.ffwd.protocol.Protocol;
@@ -45,9 +46,10 @@ public class TemplateOutputPlugin extends OutputPlugin {
         @JsonProperty("protocol") final ProtocolFactory protocol,
         @JsonProperty("retry") final RetryPolicy retry,
         @JsonProperty("filter") Optional<Filter> filter,
-        @JsonProperty("flushInterval") Optional<Long> flushInterval
+        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("batching") Optional<Batching> batching
     ) {
-        super(filter, flushInterval);
+        super(filter, Batching.from(flushInterval, batching));
         this.protocol = Optional
             .ofNullable(protocol)
             .orElseGet(ProtocolFactory.defaultFor())


### PR DESCRIPTION
Instead of specifying 'flushInterval' directly on an output plugin,
it's now possible to optionally move it within a sub structure
'batching':

```
output:
  plugins:
    - type: debug
      batching:
        flushInterval: 10000
```

This will allow adding further related configuration options here.

The old way of specifying flushInterval outside of batching is still
supported. The two methods are mutually exclusive tho.