### PR TITLE
[agent,api] Add optional metrics for batching

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/module/Batching.java
+++ b/api/src/main/java/com/spotify/ffwd/module/Batching.java
@@ -22,29 +22,38 @@ import lombok.Data;
 
 @Data
 public class Batching {
+    public static final boolean DEFAULT_REPORT_STATISTICS = false;
+
     protected final Optional<Long> flushInterval;
     protected final Optional<Long> batchSizeLimit;
     protected final Optional<Long> maxPendingFlushes;
+
+    /**
+     * Should batching-specific statistics (metrics) be reported? This adds a number of metrics.
+     */
+    protected final boolean reportStatistics;
 
     @JsonCreator
     public Batching(
         @JsonProperty("flushInterval") Optional<Long> flushInterval,
         @JsonProperty("batchSizeLimit") Optional<Long> batchSizeLimit,
-        @JsonProperty("maxPendingFlushes") Optional<Long> maxPendingFlushes
+        @JsonProperty("maxPendingFlushes") Optional<Long> maxPendingFlushes,
+        @JsonProperty("reportStatistics") Optional<Boolean> reportStatistics
     ) {
         this.flushInterval = flushInterval;
         this.batchSizeLimit = batchSizeLimit;
         this.maxPendingFlushes = maxPendingFlushes;
+        this.reportStatistics = reportStatistics.orElse(DEFAULT_REPORT_STATISTICS);
     }
 
     public static Batching empty() {
-        return from(Optional.empty(), Optional.empty(), Optional.empty());
+        return from(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public static Batching from(
         final Optional<Long> flushInterval, final Optional<Batching> batching
     ) {
-        return from(flushInterval, batching, Optional.empty());
+        return from(flushInterval, batching, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -68,6 +77,13 @@ public class Batching {
         final Optional<Long> flushInterval, final Optional<Batching> batching,
         final Optional<Long> defaultFlushInterval
     ) {
+        return from(flushInterval, batching, defaultFlushInterval, Optional.empty());
+    }
+
+    public static Batching from(
+        final Optional<Long> flushInterval, final Optional<Batching> batching,
+        final Optional<Long> defaultFlushInterval, final Optional<Boolean> reportStatistics
+    ) {
         if (flushInterval.isPresent() && batching.isPresent()) {
             throw new RuntimeException(
                 "Can't have both 'batching' and 'flushInterval' on the same level in the " +
@@ -77,8 +93,10 @@ public class Batching {
             return batching.get();
         }
         if (flushInterval.isPresent()) {
-            return new Batching(flushInterval, Optional.empty(), Optional.empty());
+            return new Batching(flushInterval, Optional.empty(), Optional.empty(),
+                Optional.empty());
         }
-        return new Batching(defaultFlushInterval, Optional.empty(), Optional.empty());
+        return new Batching(defaultFlushInterval, Optional.empty(), Optional.empty(),
+            Optional.empty());
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPluginModule.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPluginModule.java
@@ -18,6 +18,7 @@ package com.spotify.ffwd.output;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.spotify.ffwd.statistics.CoreStatistics;
 import com.spotify.ffwd.statistics.OutputPluginStatistics;
 import lombok.RequiredArgsConstructor;
@@ -40,5 +41,12 @@ public abstract class OutputPluginModule extends PrivateModule {
     @Singleton
     public OutputPluginStatistics statistics(CoreStatistics statistics) {
         return statistics.newOutputPlugin(id);
+    }
+
+    @Provides
+    @Singleton
+    @Named("pluginId")
+    public String pluginId() {
+        return id;
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/statistics/BatchingStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/BatchingStatistics.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.statistics;
+
+import eu.toolchain.async.FutureFinished;
+
+public interface BatchingStatistics {
+    /**
+     * Report that the given number of events have been sent to output plugins.
+     *
+     * @param sent The number of events sent.
+     */
+    void reportSentEvents(int sent);
+
+    /**
+     * Report that the given number of metrics have been sent to output plugins.
+     *
+     * @param sent The number of metrics sent.
+     */
+    void reportSentMetrics(int sent);
+
+    /**
+     * Report that the given number of batches have been sent to output plugins.
+     *
+     * @param sent The number of batches sent.
+     */
+    void reportSentBatches(int sent, int contentSize);
+
+    /**
+     * Report that metrics/events/batches were internally batched up into a new batch
+     *
+     * @param num The number of internal batches
+     */
+    void reportInternalBatch(int num);
+
+    /**
+     * Report metrics/events that is queued up while batching. This is a combined count for all
+     * metrics and events together, including metrics&events contained in batches.
+     *
+     * @param num The count of metrics & events that are now added to the queue
+     */
+    void reportQueueSizeInc(final int num);
+
+    /**
+     * Report that the queue of metrics/events were decreased. This happens when metrics and events
+     * were flushed by the batching plugin and the flush finished.
+     *
+     * @param num The count of metrics & events that are no longer enqueued
+     */
+    void reportQueueSizeDec(final int num);
+
+    /**
+     * Helper to monitor the completion of a write. This can be used to know the latency of writes
+     * and the number of outstanding writes.
+     *
+     * @return A FutureFinished object to be registered with a write completion future
+     */
+    FutureFinished monitorWrite();
+
+    /**
+     * Reported that the given number of events were dropped.
+     * <p>
+     * Filtered events are <em>not</em> sent to output plugins.
+     *
+     * @param dropped The number of dropped events.
+     */
+    void reportEventsDroppedByFilter(int dropped);
+
+    /**
+     * Reported that the given number of metrics were dropped.
+     * <p>
+     * Filtered metrics are <em>not</em> sent to output plugins.
+     *
+     * @param dropped The number of dropped metrics.
+     */
+    void reportMetricsDroppedByFilter(int dropped);
+}

--- a/api/src/main/java/com/spotify/ffwd/statistics/CoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/CoreStatistics.java
@@ -21,4 +21,6 @@ public interface CoreStatistics {
     public OutputManagerStatistics newOutputManager();
 
     public OutputPluginStatistics newOutputPlugin(String id);
+
+    public BatchingStatistics newBatching(String id);
 }

--- a/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -15,6 +15,8 @@
  */
 package com.spotify.ffwd.statistics;
 
+import eu.toolchain.async.FutureFinished;
+
 public class NoopCoreStatistics implements CoreStatistics {
     private static final InputManagerStatistics noopInputManagerStatistics =
         new InputManagerStatistics() {
@@ -74,6 +76,51 @@ public class NoopCoreStatistics implements CoreStatistics {
     @Override
     public OutputPluginStatistics newOutputPlugin(String id) {
         return noopOutputPluginStatistics;
+    }
+
+    public static final BatchingStatistics noopBatchingStatistics = new BatchingStatistics() {
+        @Override
+        public void reportSentEvents(final int sent) {
+        }
+
+        @Override
+        public void reportSentMetrics(final int sent) {
+        }
+
+        @Override
+        public void reportSentBatches(final int sent, final int contentSize) {
+        }
+
+        @Override
+        public void reportInternalBatch(final int num) {
+        }
+
+        @Override
+        public void reportQueueSizeInc(final int num) {
+        }
+
+        @Override
+        public void reportQueueSizeDec(final int num) {
+        }
+
+        @Override
+        public FutureFinished monitorWrite() {
+            return () -> {
+            };
+        }
+
+        @Override
+        public void reportEventsDroppedByFilter(final int dropped) {
+        }
+
+        @Override
+        public void reportMetricsDroppedByFilter(final int dropped) {
+        }
+    };
+
+    @Override
+    public BatchingStatistics newBatching(String id) {
+        return noopBatchingStatistics;
     }
 
     private static final NoopCoreStatistics instance = new NoopCoreStatistics();

--- a/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkIntegrationTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkIntegrationTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
 import com.spotify.ffwd.model.Metric;
+import com.spotify.ffwd.statistics.BatchingStatistics;
+import com.spotify.ffwd.statistics.NoopCoreStatistics;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.ResolvableFuture;
 import eu.toolchain.async.TinyAsync;
@@ -57,6 +59,8 @@ public class BatchingPluginSinkIntegrationTest {
     @Mock
     private Logger log;
 
+    private BatchingStatistics batchingStatistics = new NoopCoreStatistics().newBatching("");
+
     @Captor
     private ArgumentCaptor<Collection<Metric>> metricsCaptor;
 
@@ -78,6 +82,7 @@ public class BatchingPluginSinkIntegrationTest {
         sink.sink = childSink;
         sink.async = async;
         sink.log = log;
+        sink.batchingStatistics = batchingStatistics;
     }
 
     @After

--- a/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkTest.java
+++ b/api/src/test/java/com/spotify/ffwd/output/BatchingPluginSinkTest.java
@@ -21,9 +21,11 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
+import com.spotify.ffwd.statistics.BatchingStatistics;
 import eu.toolchain.async.AsyncFramework;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -63,6 +65,9 @@ public class BatchingPluginSinkTest {
 
     private BatchingPluginSink sink;
 
+    @Mock
+    private BatchingStatistics batchingStatistics;
+
     @Before
     public void setup() {
         sink = spy(new BatchingPluginSink(flushInterval, batchSizeLimit, maxPendingFlushes));
@@ -70,11 +75,14 @@ public class BatchingPluginSinkTest {
         sink.async = async;
         sink.log = log;
         sink.scheduler = scheduler;
+        sink.batchingStatistics = batchingStatistics;
+        when(batchingStatistics.monitorWrite()).thenReturn(() -> {});
     }
 
     @Test
     public void testDefaultConstructor() {
-        final BatchingPluginSink s = new BatchingPluginSink(1, Optional.empty(), Optional.empty());
+        final BatchingPluginSink s =
+            new BatchingPluginSink(1, Optional.empty(), Optional.empty());
 
         assertEquals(1, s.flushInterval);
         assertEquals(BatchingPluginSink.DEFAULT_BATCH_SIZE_LIMIT, s.batchSizeLimit);


### PR DESCRIPTION
Every output plugin can have an optional BatchingPluginSink in front
of it. This changes the behavior of the output, and could under high
load be a place where data is built up in queues and outstanding
writes - so it's interesting to monitor.
This commit adds some new disabled-by-default metrics for this. Enable
by specifying reportStatistics:true within the batching block for the
relevant output. Like so:

```
output:
  plugins:
    - type: debug
      batching:
        flushInterval: 10000
        reportStatistics: true
```