### PR TITLE
[batching] Add write-batch-size metric

### DIFF
--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -136,6 +136,10 @@ public class SemanticCoreStatistics implements CoreStatistics {
             private final Meter batchedCount =
                 registry.meter(m.tagged("what", "batched-into-batches", "unit", "count"));
 
+            // The size of internal batches that were written, from the batching plugin to an output
+            private final Histogram writeBatchSize =
+                registry.histogram(m.tagged("what", "write-batch-size"));
+
             // Total number of metrics & events that is currently enqueued, including batch content
             private final Counter totalEnqueued =
                 registry.counter(m.tagged("what", "total-enqueued", "unit", "count"));
@@ -172,8 +176,13 @@ public class SemanticCoreStatistics implements CoreStatistics {
             }
 
             @Override
-            public void reportInternalBatch(final int num) {
+            public void reportInternalBatchCreate(final int num) {
                 batchedCount.mark(num);
+            }
+
+            @Override
+            public void reportInternalBatchWrite(final int size) {
+                writeBatchSize.update(size);
             }
 
             @Override

--- a/api/src/main/java/com/spotify/ffwd/output/BatchingPluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/BatchingPluginSink.java
@@ -410,7 +410,7 @@ public class BatchingPluginSink implements PluginSink {
      * @return A new batch.
      */
     Batch newBatch() {
-        batchingStatistics.reportInternalBatch(1);
+        batchingStatistics.reportInternalBatchCreate(1);
         return new Batch();
     }
 

--- a/api/src/main/java/com/spotify/ffwd/statistics/BatchingStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/BatchingStatistics.java
@@ -44,7 +44,14 @@ public interface BatchingStatistics {
      *
      * @param num The number of internal batches
      */
-    void reportInternalBatch(int num);
+    void reportInternalBatchCreate(int num);
+
+    /**
+     * Report that an internally batched up batch was written
+     *
+     * @param size The size of the internal batch that was written
+     */
+    void reportInternalBatchWrite(int size);
 
     /**
      * Report metrics/events that is queued up while batching. This is a combined count for all

--- a/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -92,7 +92,11 @@ public class NoopCoreStatistics implements CoreStatistics {
         }
 
         @Override
-        public void reportInternalBatch(final int num) {
+        public void reportInternalBatchCreate(final int num) {
+        }
+
+        @Override
+        public void reportInternalBatchWrite(final int size) {
         }
 
         @Override


### PR DESCRIPTION
write-batch-size is a histogram of the size of the internal batches
that the batching plugin writes to the output.