### PR TITLE
WIP: centralised buffering

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/output/PluginSink.java
+++ b/api/src/main/java/com/spotify/ffwd/output/PluginSink.java
@@ -57,4 +57,28 @@ public interface PluginSink extends Initializable {
     AsyncFuture<Void> stop();
 
     boolean isReady();
+
+    /**
+     * Indicates if given batch would not cause buffer overflow.
+     *
+     * @param batch Batch to send.
+     * @return true if batch fits in the buffer, false otherwise
+     */
+    boolean prepareSendBatch(Batch batch);
+
+    /**
+     * Indicates if given metric would not cause buffer overflow.
+     *
+     * @param metric Metrics to send.
+     * @return true if metric fits in the buffer, false otherwise
+     */
+    boolean prepareSendMetric(Metric metric);
+
+    /**
+     * Indicates if event would not cause buffer overflow.
+     *
+     * @param events Collection of events to send.
+     * @return true if metric fits in the buffer, false otherwise
+     */
+    boolean prepareSendEvent(Event event);
 }

--- a/api/src/main/java/com/spotify/ffwd/output/TransactionOutputManager.java
+++ b/api/src/main/java/com/spotify/ffwd/output/TransactionOutputManager.java
@@ -1,0 +1,42 @@
+package com.spotify.ffwd.output;
+
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import eu.toolchain.async.AsyncFuture;
+
+public interface TransactionOutputManager {
+
+    /**
+     * Indicates if given batch would not cause buffer overflow.
+     *
+     * @param batch Batch to send.
+     * @return true if batch fits in the buffer, false otherwise
+     */
+    boolean prepareSendBatch(Batch batch);
+
+    /**
+     * Indicates if given metric would not cause buffer overflow.
+     *
+     * @param metric Metrics to send.
+     * @return true if metric fits in the buffer, false otherwise
+     */
+    boolean prepareSendMetric(Metric metric);
+
+    /**
+     * Indicates if event would not cause buffer overflow.
+     *
+     * @param events Collection of events to send.
+     * @return true if metric fits in the buffer, false otherwise
+     */
+    boolean prepareSendEvent(Event event);
+
+    AsyncFuture<Void> start();
+
+    AsyncFuture<Void> stop();
+
+    /**
+     * Populate all plugin sinks with buffered data
+     */
+    void commit();
+}

--- a/core/src/main/java/com/spotify/ffwd/output/CoreTransactionOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreTransactionOutputManager.java
@@ -1,0 +1,38 @@
+package com.spotify.ffwd.output;
+
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import eu.toolchain.async.AsyncFuture;
+
+public class CoreTransactionOutputManager implements TransactionOutputManager {
+    @Override
+    public boolean prepareSendBatch(final Batch batch) {
+        return false;
+    }
+
+    @Override
+    public boolean prepareSendMetric(final Metric metric) {
+        return false;
+    }
+
+    @Override
+    public boolean prepareSendEvent(final Event event) {
+        return false;
+    }
+
+    @Override
+    public AsyncFuture<Void> start() {
+        return null;
+    }
+
+    @Override
+    public AsyncFuture<Void> stop() {
+        return null;
+    }
+
+    @Override
+    public void commit() {
+
+    }
+}


### PR DESCRIPTION
Centralised buffering is prerequisite  for implementing backpressure in http client/http plugin.
Centralised buffering  would allow to ensure that incoming data (on input) will not cause buffer overflow in all registered output plugins. If data will cause overflow in at least one output plugin, entire call will fail. Otherwise data will be "committed" ==  populated across all output plugins.

This is very raw draft of what possibly needs to be changed in code base.

@udoprog 