### PR TITLE
 [pubsub] add output plugin

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>ffwd-module-http</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.spotify.ffwd</groupId>
+      <artifactId>ffwd-module-pubsub</artifactId>
+    </dependency>
+
     <!-- logging -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/agent/src/main/java/com/spotify/ffwd/FastForwardAgent.java
+++ b/agent/src/main/java/com/spotify/ffwd/FastForwardAgent.java
@@ -92,6 +92,7 @@ public class FastForwardAgent {
         modules.add(com.spotify.ffwd.template.TemplateOutputModule.class);
         modules.add(com.spotify.ffwd.signalfx.SignalFxModule.class);
         modules.add(com.spotify.ffwd.http.HttpModule.class);
+        modules.add(com.spotify.ffwd.pubsub.PubsubOutputModule.class);
 
         final AgentCore.Builder builder = AgentCore.builder().modules(modules);
 

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -1,0 +1,71 @@
+# FastForward Pubsub
+
+This modules provides a [Google Pubsub](https://cloud.google.com/pubsub/docs/overview) output plugin.
+
+
+## Configuration
+
+* `serviceAccount` - an optional path to a json service account to authenticate to Google.
+See [authentication](#authentication) for more info.
+* `project` - the google project where the topic exists.
+* `topic` - the google pubsub topic to publish to.
+
+
+
+The default settings the publisher uses for batching requests can be overriden. The API allows publishing
+based on request size, message count and time since last publish. The client by default automatically retries failed requests.
+
+* `requestBytesThreshold` - number of bytes to wait for.
+* `messageCountBatchSize` - number of messages to wait for.
+* `publishDelayThresholdMs` - amount of type to wait for.
+
+
+Here is an example config of setting up the pubsub plugin.
+```
+output:
+  plugins:
+    - type: pubsub
+      flushInterval: 10000
+      project: google-test-project
+      topic: test-topic
+      #serviceAccount: "path to service account json"
+```
+
+
+## Authentication
+
+If no `serviceAccount` is provided the Google Pubsub library will try to use the default credentials that are exported as part of the
+`GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+
+To learn how to setup these credentials or generate a service account read https://cloud.google.com/docs/authentication/production.
+
+## Pubsub Emulator
+
+Instead of using real Google pubsub resources, the pubsub emulator can be used for local development.
+
+Follow https://cloud.google.com/pubsub/docs/emulator to setup and start the emulator. 
+
+Start ffwd after exporting an environment variable like below to point at the emulator.
+`export PUBSUB_EMULATOR_HOST=localhost:8085` 
+
+Note - no topics or subscriptions are created by default. You can use the python pubsub library like so...
+
+TODO - Move this to a utility class in Java.
+
+
+```python
+from google.cloud import pubsub_v1
+
+project = 'google-test-project'
+p = pubsub_v1.PublisherClient()
+tp = p.topic_path(project, 'test-topic')
+p.create_topic(tp)
+
+c = pubsub_v1.SubscriberClient()
+sp = c.subscription_path(project, 'test-subscription')
+c.create_subscription(sp, tp)
+
+c.pull(sp, 1)
+
+```

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -1,0 +1,117 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.spotify.ffwd</groupId>
+        <artifactId>ffwd-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ffwd-module-pubsub</artifactId>
+    <packaging>jar</packaging>
+    <name>FastForward Pubsub Module</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.spotify.ffwd</groupId>
+            <artifactId>ffwd-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-pubsub</artifactId>
+            <version>1.36.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>20.0</version>
+        </dependency>
+
+      <!-- testing -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.ffwd</groupId>
+        <artifactId>ffwd-core</artifactId>
+        <scope>test</scope>
+      </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <!-- https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/TROUBLESHOOTING.md#resolving-the-conflict -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>eu.toolchain.async:*</exclude>
+                                    <exclude>org.apache:*</exclude>
+                                    <exclude>com.fasterxml:*</exclude>
+                                    <exclude>io.netty:*</exclude>
+                                </excludes>
+                            </artifactSet>
+
+                            <relocations>
+                                <!-- move protobuf to a shaded package -->
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>com.spotify.ffwd.pubsub.shaded.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <!-- move Guava to a shaded package -->
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>com.spotify.ffwd.pubsub.shaded.com.google.common</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputModule.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.pubsub;
+
+import com.google.inject.Inject;
+import com.spotify.ffwd.module.FastForwardModule;
+import com.spotify.ffwd.module.PluginContext;
+import lombok.ToString;
+
+@ToString()
+public class PubsubOutputModule implements FastForwardModule {
+    @Inject
+    private PluginContext context;
+
+    @Override
+    public void setup() {
+        context.registerOutput("pubsub", PubsubOutputPlugin.class);
+    }
+}

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2013-2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.pubsub;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.base.Preconditions;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.name.Names;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.spotify.ffwd.filter.Filter;
+import com.spotify.ffwd.module.Batching;
+import com.spotify.ffwd.output.OutputPlugin;
+import com.spotify.ffwd.output.OutputPluginModule;
+import com.spotify.ffwd.output.PluginSink;
+import com.spotify.ffwd.serializer.Serializer;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Optional;
+import org.threeten.bp.Duration;
+
+public class PubsubOutputPlugin extends OutputPlugin {
+
+  private static final long DEFAULT_BYTES_THRESHOLD = 5000L;
+  private static final long DEFAULT_COUNT_THRESHOLD = 1000L;
+  private static final long DEFAULT_DELAY_THRESHOLD = Duration.ofMillis(200).toMillis();
+
+  private final Optional<Serializer> serializer;
+
+  private final Optional<String> serviceAccount;
+  private final Optional<String> project;
+  private final Optional<String> topic;
+
+  private final long requestBytesThreshold;
+  private final long messageCountBatchSize;
+  private final Duration publishDelayThreshold;
+
+  @JsonCreator
+  public PubsubOutputPlugin(
+    @JsonProperty("filter") Optional<Filter> filter,
+    @JsonProperty("flushInterval") Optional<Long> flushInterval,
+    @JsonProperty("batching") Optional<Batching> batching,
+    @JsonProperty("serializer") Serializer serializer,
+
+    @JsonProperty("serviceAccount") String serviceAccount,
+    @JsonProperty("project") String project,
+    @JsonProperty("topic") String topic,
+
+    @JsonProperty("requestBytesThreshold") Long requestBytesThreshold,
+    @JsonProperty("messageCountBatchSize") Long messageCountBatchSize,
+    @JsonProperty("publishDelayThresholdMs") Long publishDelayThresholdMs
+  ) {
+    super(filter, Batching.from(flushInterval, batching));
+    this.serializer = Optional.ofNullable(serializer);
+
+    this.serviceAccount = Optional.ofNullable(serviceAccount);
+    this.project = Optional.ofNullable(project);
+    this.topic = Optional.ofNullable(topic);
+
+    this.requestBytesThreshold = Optional.ofNullable(
+      requestBytesThreshold).orElse(DEFAULT_BYTES_THRESHOLD);
+    this.messageCountBatchSize = Optional.ofNullable(
+      messageCountBatchSize).orElse(DEFAULT_COUNT_THRESHOLD);
+    this.publishDelayThreshold = Duration.ofMillis(
+      Optional.ofNullable(publishDelayThresholdMs).orElse(DEFAULT_DELAY_THRESHOLD));
+  }
+
+  @Override
+  public Module module(final Key<PluginSink> key, final String id) {
+    return new OutputPluginModule(id) {
+
+      @Provides
+      @Singleton
+      public ProjectTopicName topicName() {
+        Preconditions.checkArgument(project.isPresent(), "Google project must be set in config");
+        Preconditions.checkArgument(topic.isPresent(), "Pubsub topic must be set in config");
+        return ProjectTopicName.of(project.get(), topic.get());
+      }
+
+      @Provides
+      @Singleton
+      public Publisher publisher() throws IOException {
+        // Publish request based on request size, messages count & time since last publish
+        BatchingSettings batchingSettings = BatchingSettings.newBuilder()
+          .setElementCountThreshold(messageCountBatchSize)
+          .setRequestByteThreshold(requestBytesThreshold)
+          .setDelayThreshold(publishDelayThreshold)
+          .build();
+
+        ExecutorProvider executorProvider = InstantiatingExecutorProvider.newBuilder()
+          .setExecutorThreadCount(1).build();
+
+
+        final Publisher.Builder publisher = Publisher.newBuilder(topicName())
+          .setBatchingSettings(batchingSettings)
+          .setExecutorProvider(executorProvider);
+
+        if (serviceAccount.isPresent()) {
+          CredentialsProvider credentials =
+            FixedCredentialsProvider.create(
+              ServiceAccountCredentials.fromStream(new FileInputStream(serviceAccount.get())));
+          publisher.setCredentialsProvider(credentials);
+        }
+
+        final String emulatorHost = System.getenv("PUBSUB_EMULATOR_HOST");
+        if (emulatorHost != null) {
+          ManagedChannel channel =
+            ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
+          TransportChannelProvider channelProvider =
+            FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+
+          publisher.setChannelProvider(channelProvider);
+          publisher.setCredentialsProvider(NoCredentialsProvider.create());
+        }
+
+        return publisher.build();
+      }
+
+
+      @Override
+      protected void configure() {
+        if (serializer.isPresent()) {
+          bind(Serializer.class).toInstance(serializer.get());
+        } else {
+          bind(Serializer.class).to(Key.get(Serializer.class, Names.named("default")));
+        }
+
+        final Key<PubsubPluginSink> sinkKey =
+          Key.get(PubsubPluginSink.class, Names.named("pubsubSink"));
+        bind(sinkKey).to(PubsubPluginSink.class).in(Scopes.SINGLETON);
+        install(wrapPluginSink(sinkKey, key));
+        expose(key);
+      }
+    };
+  }
+}

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2013-2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.pubsub;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Batch.Point;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import com.spotify.ffwd.output.BatchablePluginSink;
+import com.spotify.ffwd.serializer.Serializer;
+import eu.toolchain.async.AsyncFramework;
+import eu.toolchain.async.AsyncFuture;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This output plugin sends metrics to Google pubsub.
+ *
+ * Notice most of the methods return `async.resolved()`. This is because there's no apparent way to
+ * map from `ApiFuture` to `AsyncFuture` and the PluginSink that executes this one calls
+ * `collectAndDiscard` on the futures anyway.
+ */
+@Slf4j
+public class PubsubPluginSink implements BatchablePluginSink {
+
+  @Inject
+  AsyncFramework async;
+
+  @Inject
+  Publisher publisher;
+
+  @Inject
+  Serializer serializer;
+
+  @Inject
+  TopicAdmin topicAdmin;
+
+  @Inject
+  ProjectTopicName topicName;
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public void init() { }
+
+  @Override
+  public AsyncFuture<Void> sendEvents(Collection<Event> events) {
+    for (Event event : events) {
+      try {
+        publisher.publish(PubsubMessage.newBuilder()
+          .setData(ByteString.copyFrom(serializer.serialize(event))).build()
+        );
+      } catch (Exception e) {
+        log.error("Failed to publish event {}", e);
+      }
+    }
+
+    return async.resolved();
+  }
+
+  @Override
+  public AsyncFuture<Void> sendMetrics(Collection<Metric> metrics) {
+    for (Metric metric : metrics) {
+      try {
+        publisher.publish(PubsubMessage.newBuilder()
+          .setData(ByteString.copyFrom(serializer.serialize(metric)))
+          .build()
+        );
+      } catch (Exception e) {
+        log.error("Failed to publish metric {}", e);
+      }
+    }
+
+    return async.resolved();
+  }
+
+  @Override
+  public AsyncFuture<Void> sendBatches(Collection<Batch> batches) {
+    // TODO(dmichel): should this support events?
+    final ArrayList<Metric> metrics = new ArrayList<>();
+
+    batches.forEach(batch -> {
+      batch.getPoints().forEach(point -> {
+        metrics.add(convertBatchMetric(batch, point));
+      });
+    });
+
+    return sendMetrics(metrics);
+  }
+
+  private Metric convertBatchMetric(final Batch batch, final Point point) {
+    final Map<String, String> allTags = new HashMap<>(batch.getCommonTags());
+    allTags.putAll(point.getTags());
+
+    final Map<String, String> allResource = new HashMap<>(batch.getCommonResource());
+    allResource.putAll(point.getResource());
+
+    return new Metric(point.getKey(), point.getValue(), new Date(point.getTimestamp()),
+      ImmutableSet.of(), allTags, allResource, null);
+  }
+
+  @Override
+  public void sendEvent(final Event event) {
+    sendEvents(Collections.singletonList(event));
+  }
+
+  @Override
+  public void sendMetric(final Metric metric) {
+    sendMetrics(Collections.singletonList(metric));
+  }
+
+  @Override
+  public void sendBatch(final Batch batch) {
+    sendBatches(Collections.singletonList(batch));
+  }
+
+
+  /**
+   * If the service account permissions allow it, check to see if the topic exists. Topic
+   * creation is handled outside of this plugin as to limit the privileges given to the producer.
+   */
+  @Override
+  public AsyncFuture<Void> start() {
+    log.info("Connecting to topic {}", topicName);
+    try {
+      topicAdmin.getClient().getTopic(topicName);
+      log.info("Topic exists");
+    } catch (IOException e) {
+      log.error("Topic admin", e);
+    } catch (NotFoundException e) {
+      log.warn("Topic {} not found or permission issues", topicName);
+    }
+    return async.resolved();
+  }
+
+  @Override
+  public AsyncFuture<Void> stop() {
+    return async.call(() -> {
+      publisher.shutdown();
+      return null;
+    });
+  }
+
+}

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/TopicAdmin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/TopicAdmin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2018 Spotify AB. All rights reserved.
+ *
+ * The contents of this file are licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.ffwd.pubsub;
+
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
+
+
+public class TopicAdmin {
+
+  @Provides
+  @Singleton
+  public TopicAdminClient getClient() throws IOException {
+    final TopicAdminSettings.Builder adminSetting = TopicAdminSettings.newBuilder();
+
+    final String emulatorHost = System.getenv("PUBSUB_EMULATOR_HOST");
+    if (emulatorHost != null) {
+      ManagedChannel channel =
+        ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
+      TransportChannelProvider channelProvider =
+        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+
+      adminSetting.setTransportChannelProvider(channelProvider);
+      adminSetting.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    return TopicAdminClient.create(adminSetting.build());
+  }
+
+}

--- a/modules/pubsub/src/test/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
+++ b/modules/pubsub/src/test/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
@@ -1,0 +1,76 @@
+package com.spotify.ffwd.pubsub;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.pubsub.v1.PubsubMessage;
+import com.spotify.ffwd.model.Batch;
+import com.spotify.ffwd.model.Event;
+import com.spotify.ffwd.model.Metric;
+import com.spotify.ffwd.serializer.ToStringSerializer;
+import eu.toolchain.async.AsyncFramework;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PubsubPluginSinkTest {
+
+    @Mock
+    private AsyncFramework async;
+
+    @Mock
+    private Publisher publisher;
+
+    private PubsubPluginSink sink;
+
+    @Before
+    public void setUp() throws Exception {
+        sink = spy(new PubsubPluginSink());
+        sink.async = async;
+        sink.publisher = publisher;
+        sink.serializer = new ToStringSerializer();
+    }
+
+    private Event makeEvent() {
+        return new Event("test_event", 1278, new Date(), 12L, "critical", "test_event", "test_host",
+            ImmutableSet.of(), ImmutableMap.of("what", "stats", "pod", "gew1"));
+    }
+    private Metric makeMetric() {
+        return new Metric("key1", 1278, new Date(), ImmutableSet.of(),
+                ImmutableMap.of("what", "test"), ImmutableMap.of(), null);
+    }
+
+    @Test
+    public void testSendEvent() {
+        sink.sendEvent(makeEvent());
+        verify(publisher).publish(any(PubsubMessage.class));
+    }
+
+    @Test
+    public void testSendMetric() {
+        sink.sendMetric(makeMetric());
+        verify(publisher).publish(any(PubsubMessage.class));
+    }
+
+
+    @Test
+    public void testSendBatch() {
+        final Batch batch = Batch.create(Optional.of(ImmutableMap.of("tag1", "foo")),
+            Optional.of(ImmutableMap.of("resource", "foo")),
+            ImmutableList.of(makeMetric().toBatchPoint()));
+
+        sink.sendBatch(batch);
+        verify(publisher).publish(any(PubsubMessage.class));
+    }
+
+}

--- a/modules/riemann/pom.xml
+++ b/modules/riemann/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>ffwd-module-riemann</artifactId>
   <packaging>jar</packaging>
-  <name>FastForward Kafka Module</name>
+  <name>FastForward Riemann Module</name>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>modules/json</module>
     <module>modules/signalfx</module>
     <module>modules/http</module>
+    <module>modules/pubsub</module>
     <module>ffwd-http-client</module>
   </modules>
 
@@ -175,6 +176,11 @@
       <dependency>
         <groupId>com.spotify.ffwd</groupId>
           <artifactId>ffwd-module-http</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.spotify.ffwd</groupId>
+        <artifactId>ffwd-module-pubsub</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This plugin allows for outputting metrics to Google Pubsub.

It allows for local testing via the pubsub emulator. See the readme on setup instructions. 


 
Threading appears to be setup correctly as not to block the main ffwd thread (looks okay) but the grpc thread count doesn't seem to be tunable (?). Let's see how this runs on a few instances internally.

<img width="1081" alt="screen shot 2018-07-20 at 1 37 41 pm" src="https://user-images.githubusercontent.com/677960/43018152-ac49d538-8c26-11e8-9dc7-27d537c704ee.png">

