### PR TITLE
[all] bump log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <skip.findbugs>true</skip.findbugs>
     <guice.version>4.0-beta5</guice.version>
     <tiny-async.version>1.11.0</tiny-async.version>
-    <log4j.version>2.2</log4j.version>
+    <log4j.version>2.11.1</log4j.version>
     <slf4j.version>1.7.10</slf4j.version>
     <jackson.version>2.9.3</jackson.version>
   </properties>


### PR DESCRIPTION
A newer log4j version is required to delete old log files.

At startup ffwd used to log an error...
`ERROR DefaultRolloverStrategy contains an invalid element or attribute "Delete"`

@jsferrei @sjoeboo 