### PR TITLE
Fixes to the release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .*.swp~
 .*.un~
-target
 *.class
 *.iml
 .classpath
@@ -11,3 +10,11 @@ target
 dependency-reduced-pom.xml
 /.cache/*
 .DS_Store
+
+# Build products and artifacts
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,28 @@
+To release `ffwd` run the below command. Ensure you are following the [semantic versioning](https://semver.org/) when creating a release!
+
+
+You will need the following:
+
+* GPG set up on the machine you're deploying from
+
+Preparing a release goes through the [following](https://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html) release phases: 
+
+* Check that there are no uncommitted changes in the sources
+* Check that there are no SNAPSHOT dependencies
+* Change the version in the POMs from x-SNAPSHOT to a new version (you will be prompted for the versions to use)
+* Transform the SCM information in the POM to include the final destination of the tag
+* Run the project tests against the modified POMs to confirm everything is in working order
+* Commit the modified POMs
+* Tag the code in the SCM with a version name (this will be prompted for)
+* Bump the version in the POMs to a new value y-SNAPSHOT (these values will also be prompted for)
+* Commit the modified POMs
+
+
+```
+# make and deploy a release
+mvn release:clean release:prepare -Prelease
+
+```
+
+
+Then update https://github.com/spotify/ffwd/releases with release notes!

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -36,5 +36,5 @@ override_dh_auto_clean:
 override_dh_auto_build:
 	$(MVN) package
 	mkdir -p $(BUILD)
-	cp agent/target/ffwd-agent-0.0.1-SNAPSHOT.jar $(FFWD_JAR)
+	cp agent/target/ffwd-agent-RELEASE.jar $(FFWD_JAR)
 	cp debian/bin/ffwd-java $(FFWD)

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <scm>
     <connection>scm:git:git@github.com:spotify/ffwd</connection>
     <developerConnection>scm:git:git@github.com:spotify/ffwd</developerConnection>
-    <url>https://github.com/udoprog/ffwd-client-java</url>
+    <url>https://github.com/spotify/ffwd</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
The main change here is to add the correct release version to the debian package. Previously this was hardcoded to `0.0.1-SNAPSHOT` and would fail with...

```
cp agent/target/ffwd-agent-0.0.1-SNAPSHOT.jar build/ffwd-full.jar
cp: cannot stat ‘agent/target/ffwd-agent-0.0.1-SNAPSHOT.jar’: No such file or directory
```

This also adds instructions on how to perform a release.

@sjoeboo 