### PR TITLE
Drop "v" from git tag

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/modules/carbon/pom.xml
+++ b/modules/carbon/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/kafka/pom.xml
+++ b/modules/kafka/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/protobuf/pom.xml
+++ b/modules/protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.spotify.ffwd</groupId>
         <artifactId>ffwd-parent</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/riemann/pom.xml
+++ b/modules/riemann/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/signalfx/pom.xml
+++ b/modules/signalfx/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../..</relativePath>
   </parent>
 

--- a/modules/template/pom.xml
+++ b/modules/template/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify.ffwd</groupId>
   <artifactId>ffwd-parent</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>FastForward Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,14 @@
             <exclude>**/protobuf250/**</exclude>
           </excludes>
         </configuration>
+      </plugin>
 
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration combine.self="append">
+          <tagNameFormat>@{project.version}</tagNameFormat>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/protobuf250/pom.xml
+++ b/protobuf250/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
The produced jar file that is contained with the debian package is not prefixed with a “v”.

@lmuhlha @Dbochman 