### PR TITLE
Add batching/compression when using pubsub output

### DIFF
--- a/agent/ffwd-local-pubsub-debug.yaml
+++ b/agent/ffwd-local-pubsub-debug.yaml
@@ -6,18 +6,14 @@ input:
     - type: json
       protocol:
         type: udp
+        receiveBufferSize: 26214400
     - type: protobuf
       protocol:
         type: udp
+        receiveBufferSize: 26214400
     - type: protobuf
       protocol:
         type: tcp
-    - type: riemann
-      protocol:
-        type: tcp
-    - type: riemann
-      protocol:
-        type: udp
     - type: http
       protocol:
         type: tcp
@@ -27,8 +23,15 @@ output:
     - type: debug
     - type: pubsub
       serializer:
-        type: spotify100
-      flushInterval: 10000
+        type: spotify100proto
+
+      batching:
+        flushInterval: 10000
+        batchSizeLimit: 10000  # Default: 10000
+        maxPendingFlushes: 10 # Default: 10
+
       project: google-test-project
       topic: test-topic
-      #serviceAccount: /path/to/creds.json
+      requestBytesThreshold: 25000 # Default: 5000
+      messageCountBatchSize: 10 # Default: 1000
+      publishDelayThresholdMs: 200 # Default: 200

--- a/api/src/main/java/com/spotify/ffwd/serializer/Serializer.java
+++ b/api/src/main/java/com/spotify/ffwd/serializer/Serializer.java
@@ -23,10 +23,13 @@ package com.spotify.ffwd.serializer;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
+import java.util.Collection;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface Serializer {
     byte[] serialize(Event event) throws Exception;
 
     byte[] serialize(Metric metric) throws Exception;
+
+    byte[] serialize(Collection<Metric> metrics) throws Exception;
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>guice</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
@@ -27,6 +27,7 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
+import java.util.Collection;
 import java.util.Map;
 import lombok.Data;
 
@@ -76,6 +77,11 @@ public class Spotify100Serializer implements Serializer {
             new Spotify100Metric(source.getKey(), source.getTime().getTime(),
                 source.getTags(), source.getResource(), source.getValue());
         return mapper.writeValueAsBytes(m);
+    }
+
+    @Override
+    public byte[] serialize(Collection<Metric> metrics) throws Exception {
+        throw new UnsupportedOperationException("Not supported");
     }
 }
 

--- a/core/src/main/java/com/spotify/ffwd/serializer/ToStringSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/ToStringSerializer.java
@@ -23,6 +23,7 @@ package com.spotify.ffwd.serializer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
+import java.util.Collection;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 
@@ -41,6 +42,11 @@ public class ToStringSerializer implements Serializer {
     @Override
     public byte[] serialize(Metric metric) throws Exception {
         return metric.toString().getBytes();
+    }
+
+    @Override
+    public byte[] serialize(Collection<Metric> metrics) throws Exception {
+        throw new UnsupportedOperationException("Not supported");
     }
 
     public static Supplier<Serializer> defaultSupplier() {

--- a/core/src/main/proto/spotify_100.proto
+++ b/core/src/main/proto/spotify_100.proto
@@ -25,3 +25,7 @@ message Metric {
 message Message {
     Metric metric = 1;
 }
+
+message Batch {
+    repeated Metric metric = 1;
+}

--- a/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
+++ b/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
@@ -20,9 +20,10 @@
 
 package com.spotify.ffwd.serializer;
 
-import static org.hamcrest.CoreMatchers.any;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.spotify.ffwd.model.Metric;
@@ -32,17 +33,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestSpotify100ProtoSerializer {
-  private Spotify100ProtoSerializer spotify100ProtoSerializer;
-  private Metric metric;
+  private Serializer serializer;
+  private Metric metric1;
 
   @Before
   public void setup() {
-    spotify100ProtoSerializer = new Spotify100ProtoSerializer();
+    serializer = new Spotify100ProtoSerializer();
   }
 
-  @Test
+  @Test(expected = UnsupportedOperationException.class)
   public void testSerializeMetric() throws Exception {
-    metric = new Metric("",
+    metric1 = new Metric("",
       0.0,
       Date.from(Instant.ofEpochSecond(1542812184)),
       ImmutableSet.of(),
@@ -50,14 +51,12 @@ public class TestSpotify100ProtoSerializer {
       ImmutableMap.of(),
       "");
 
-    final byte[] serialize = spotify100ProtoSerializer.serialize(metric);
-
-    assertThat(serialize, any(byte[].class));
+    serializer.serialize(metric1);
   }
 
   @Test(expected = NullPointerException.class)
   public void testNullKeyException() throws Exception {
-    metric = new Metric(null,
+    metric1 = new Metric(null,
       0.0,
       Date.from(Instant.ofEpochSecond(1542812184)),
       ImmutableSet.of(),
@@ -65,7 +64,34 @@ public class TestSpotify100ProtoSerializer {
       ImmutableMap.of(),
       "");
 
-    spotify100ProtoSerializer.serialize(metric);
+    serializer.serialize(ImmutableList.of(metric1));
+  }
+
+  @Test
+  public void testSerializeMetrics() throws Exception {
+    metric1 = new Metric("",
+      0.0,
+      Date.from(Instant.ofEpochSecond(1542812184)),
+      ImmutableSet.of(),
+      ImmutableMap.of("tag-a", "foo"),
+      ImmutableMap.of("resource-a", "bar"),
+      "");
+    final Metric metric2 = new Metric("",
+      1.0,
+      Date.from(Instant.ofEpochSecond(1542812190)),
+      ImmutableSet.of(),
+      ImmutableMap.of("tag-a", "foo"),
+      ImmutableMap.of("resource-a", "bar"),
+      "");
+
+    final byte[] serialize = serializer.serialize(ImmutableList.of(metric1, metric2));
+
+    assertThat(serialize, is(
+      new byte[]{93, -120, 10, 40, 16, -64, -37, -106, -74, -13, 44, 34, 12, 10, 5, 116, 97, 103,
+                 45, 97, 18, 3, 102, 111, 111, 42, 17, 10, 10, 114, 101, 115, 111, 117, 114, 99,
+                 101, 1, 19, 52, 98, 97, 114, 10, 49, 16, -80, -118, -105, -74, -13, 44, 25, 0, 5,
+                 1, 4, -16, 63, -126, 51, 0})
+    );
   }
 
 }

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.spotify.ffwd</groupId>
+            <artifactId>ffwd-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
             <version>1.36.0</version>
@@ -57,13 +62,6 @@
         <artifactId>mockito-core</artifactId>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>com.spotify.ffwd</groupId>
-        <artifactId>ffwd-core</artifactId>
-        <scope>test</scope>
-      </dependency>
-
-
     </dependencies>
 
     <build>

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
@@ -20,6 +20,9 @@
 
 package com.spotify.ffwd.pubsub;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Optional.ofNullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.api.gax.batching.BatchingSettings;
@@ -30,7 +33,6 @@ import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
-import com.google.common.base.Preconditions;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -82,18 +84,16 @@ public class PubsubOutputPlugin extends OutputPlugin {
     @JsonProperty("publishDelayThresholdMs") Long publishDelayThresholdMs
   ) {
     super(filter, Batching.from(flushInterval, batching));
-    this.serializer = Optional.ofNullable(serializer);
+    this.serializer = ofNullable(serializer);
 
-    this.serviceAccount = Optional.ofNullable(serviceAccount);
-    this.project = Optional.ofNullable(project);
-    this.topic = Optional.ofNullable(topic);
+    this.serviceAccount = ofNullable(serviceAccount);
+    this.project = ofNullable(project);
+    this.topic = ofNullable(topic);
 
-    this.requestBytesThreshold = Optional.ofNullable(
-      requestBytesThreshold).orElse(DEFAULT_BYTES_THRESHOLD);
-    this.messageCountBatchSize = Optional.ofNullable(
-      messageCountBatchSize).orElse(DEFAULT_COUNT_THRESHOLD);
+    this.requestBytesThreshold = ofNullable(requestBytesThreshold).orElse(DEFAULT_BYTES_THRESHOLD);
+    this.messageCountBatchSize = ofNullable(messageCountBatchSize).orElse(DEFAULT_COUNT_THRESHOLD);
     this.publishDelayThreshold = Duration.ofMillis(
-      Optional.ofNullable(publishDelayThresholdMs).orElse(DEFAULT_DELAY_THRESHOLD));
+      ofNullable(publishDelayThresholdMs).orElse(DEFAULT_DELAY_THRESHOLD));
   }
 
   @Override
@@ -103,8 +103,8 @@ public class PubsubOutputPlugin extends OutputPlugin {
       @Provides
       @Singleton
       public ProjectTopicName topicName() {
-        Preconditions.checkArgument(project.isPresent(), "Google project must be set in config");
-        Preconditions.checkArgument(topic.isPresent(), "Pubsub topic must be set in config");
+        checkArgument(project.isPresent(), "Google project must be set in config");
+        checkArgument(topic.isPresent(), "Pubsub topic must be set in config");
         return ProjectTopicName.of(project.get(), topic.get());
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,15 @@
         <version>0.0.3</version>
       </dependency>
 
+
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.7.2</version>
+        <type>jar</type>
+        <scope>compile</scope>
+      </dependency>
+
       <!-- logging -->
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
<odify the proto schema to send batches and compresses metrics using the snappy library.  In my testing this reduced the payload to Google Pubsub from 10,976 bytes to 1,984 bytes which is a ~81% savings. This is a breaking change.

@hexedpackets @jsferrei @lmuhlha 

