### PR TITLE
Fix NullPointerException; Fix Pubsub executor

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -14,9 +14,8 @@
   </parent>
 
   <properties>
-    <spotify-metrics.version>1.0.1</spotify-metrics.version>
+    <spotify-metrics.version>1.0.2</spotify-metrics.version>
   </properties>
-
 
   <dependencies>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,12 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/modules/json/src/main/java/com/spotify/ffwd/json/JsonObjectMapperDecoder.java
+++ b/modules/json/src/main/java/com/spotify/ffwd/json/JsonObjectMapperDecoder.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -110,16 +111,14 @@ public class JsonObjectMapperDecoder extends MessageToMessageDecoder<ByteBuf> {
         final String key = decodeString(tree, "key");
         final double value = decodeDouble(tree, "value");
         final Date time = decodeTime(tree, "time");
-        final String host = decodeString(tree, HOST);
+        final Optional<String> host = Optional.ofNullable(decodeString(tree, HOST));
         final Set<String> riemannTags = decodeTags(tree, "tags");
         final Map<String, String> tags = decodeAttributes(tree, "attributes");
         // TODO: support resource?
         final Map<String, String> resource = ImmutableMap.of();
         final String proc = decodeString(tree, "proc");
 
-        if (host != null) {
-            tags.put(HOST, host);
-        }
+        host.ifPresent(h -> tags.put(HOST, h));
 
         return new Metric(key, value, time, riemannTags, tags, resource, proc);
     }
@@ -172,7 +171,7 @@ public class JsonObjectMapperDecoder extends MessageToMessageDecoder<ByteBuf> {
     String decodeString(JsonNode tree, String name) {
         final JsonNode n = tree.get(name);
 
-        if (n.isNull()) {
+        if (n == null || n.isNull()) {
             return null;
         }
 

--- a/modules/json/src/test/java/com/spotify/ffwd/json/JsonObjectMapperDecoderTest.java
+++ b/modules/json/src/test/java/com/spotify/ffwd/json/JsonObjectMapperDecoderTest.java
@@ -46,4 +46,12 @@ public class JsonObjectMapperDecoderTest {
     assertNull(key);
   }
 
+  @Test
+  public void noHostInJson() throws IOException {
+    final JsonNode json = mapper.readTree("{\"key\": null}");
+    final String host = j.decodeString(json, "host");
+
+    assertNull(host);
+  }
+
 }

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>27.0.1-jre</version>
         </dependency>
 
       <!-- testing -->

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
@@ -26,7 +26,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.ProjectTopicName;
@@ -47,8 +47,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -77,8 +76,7 @@ public class PubsubPluginSink implements BatchablePluginSink {
   ProjectTopicName topicName;
 
 
-  private final ExecutorService executorService = Executors.newCachedThreadPool(
-    new ThreadFactoryBuilder().setNameFormat("ffwd-pubsub-callback-%d").build());
+  private final Executor executorService = MoreExecutors.directExecutor();
 
   @Override
   public boolean isReady() {

--- a/modules/signalfx/pom.xml
+++ b/modules/signalfx/pom.xml
@@ -23,6 +23,12 @@
       <groupId>com.signalfx.public</groupId>
       <artifactId>signalfx-java</artifactId>
       <version>0.0.27</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <skip.findbugs>true</skip.findbugs>
-    <guice.version>4.0-beta5</guice.version>
+    <guice.version>4.2.2</guice.version>
     <tiny-async.version>1.11.0</tiny-async.version>
     <log4j.version>2.11.1</log4j.version>
-    <slf4j.version>1.7.10</slf4j.version>
-    <jackson.version>2.9.3</jackson.version>
+    <slf4j.version>1.7.25</slf4j.version>
+    <jackson.version>2.9.5</jackson.version>
   </properties>
 
   <profiles>
@@ -227,7 +227,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
       </dependency>
 
       <dependency>
@@ -277,7 +277,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>18.0</version>
+        <version>27.0.1-jre</version>
       </dependency>
 
       <dependency>
@@ -406,6 +406,21 @@
         <configuration combine.self="append">
           <tagNameFormat>@{project.version}</tagNameFormat>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
A few commits that are part of this pull request:

* add maven enforcer plugin to catch upper bound dependency issues.
* fix NullPointerException exception bug when key is missing.
* fix pubsub callback executor. Run callback for publishing messages on the same thread that is executing it rather than using a different pool. This is a remediation from an incident where ffwd went OOM on some instances due to the unbounded executor services where there were 1000’s of threads.

@hexedpackets 