### PR TITLE
revert change that removed `.close()`. sending metrics via curl/etc

### DIFF
--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpDecoder.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpDecoder.java
@@ -99,7 +99,7 @@ public class HttpDecoder extends MessageToMessageDecoder<FullHttpRequest> {
         ctx
             .channel()
             .writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK))
-            .addListener((ChannelFutureListener) future -> future.channel());
+            .addListener((ChannelFutureListener) future -> future.channel().close());
     }
 
     private void getPing(
@@ -108,6 +108,6 @@ public class HttpDecoder extends MessageToMessageDecoder<FullHttpRequest> {
         ctx
             .channel()
             .writeAndFlush(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK))
-            .addListener((ChannelFutureListener) future -> future.channel());
+            .addListener((ChannelFutureListener) future -> future.channel().close());
     }
 }


### PR DESCRIPTION
would work but hang the client.