### PR TITLE
Add an expiring writeCache

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -14,10 +14,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <properties>
-    <spotify-metrics.version>1.0.2</spotify-metrics.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -81,6 +77,15 @@
       <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>semantic-metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>semantic-metrics-ffwd-reporter</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -98,18 +103,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- semantic metrics -->
-    <dependency>
-      <groupId>com.spotify.metrics</groupId>
-      <artifactId>semantic-metrics-core</artifactId>
-      <version>${spotify-metrics.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.spotify.metrics</groupId>
-      <artifactId>semantic-metrics-ffwd-reporter</artifactId>
-      <version>${spotify-metrics.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -29,6 +29,8 @@ import com.spotify.metrics.core.MetricId;
 import com.spotify.metrics.core.SemanticMetricBuilder;
 import com.spotify.metrics.core.SemanticMetricRegistry;
 import eu.toolchain.async.FutureFinished;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 
@@ -146,12 +148,23 @@ public class SemanticCoreStatistics implements CoreStatistics {
         final MetricId m = metric.tagged("component", "output-plugin", "plugin_id", id);
 
         return new OutputPluginStatistics() {
-            private final Meter dropped =
-                registry.meter(m.tagged("what", "dropped-metrics", "unit", "metric"));
+            private final Meter dropped = registry.meter(
+                m.tagged("what", "dropped-metrics", "unit", "metric"));
+            private Map<MetricId, Metric> gauges = Collections.emptyMap();
+
+            @Override
+            public Map<MetricId, Metric> getMetrics() {
+                return this.gauges;
+            }
 
             @Override
             public void reportDropped(int dropped) {
                 this.dropped.mark(dropped);
+            }
+
+            @Override
+            public void registerCacheStats(SemanticCacheStatistics s) {
+                registry.register(m, s);
             }
         };
     }

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,6 +59,11 @@
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.spotify.metrics</groupId>
+      <artifactId>semantic-metrics-core</artifactId>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/api/src/main/java/com/spotify/ffwd/cache/ExpiringCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/ExpiringCache.java
@@ -41,7 +41,7 @@ public class ExpiringCache implements WriteCache {
   }
 
   @Override
-  public boolean isCached(final Metric metric) {
+  public boolean checkCacheOrSet(final Metric metric) {
     if (writeCache.getIfPresent(metric.generateHash()) != null) {
       log.trace("Metric in cache: {}", metric);
       return true;

--- a/api/src/main/java/com/spotify/ffwd/cache/ExpiringCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/ExpiringCache.java
@@ -1,0 +1,53 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+
+package com.spotify.ffwd.cache;
+
+import com.google.common.cache.Cache;
+import com.spotify.ffwd.model.Metric;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ExpiringCache is useful to reduce the number of metrics being published to a topic. Typically
+ * processing and de-deduplication of the "metadata" around a metric only needs to happen every so
+ * often. In the case of using Heroic, this "metadata" only needs to be published at the interval of
+ * a new index being created.
+ */
+public class ExpiringCache implements WriteCache {
+  private static final Logger log = LoggerFactory.getLogger(ExpiringCache.class);
+  private final Cache<String, Boolean> writeCache;
+
+  public ExpiringCache(final Cache<String, Boolean> writeCache) {
+    this.writeCache = writeCache;
+  }
+
+  @Override
+  public boolean isCached(final Metric metric) {
+    if (writeCache.getIfPresent(metric.generateHash()) != null) {
+      log.trace("Metric in cache: {}", metric);
+      return true;
+    }
+    writeCache.put(metric.generateHash(), true);
+    return false;
+  }
+
+}

--- a/api/src/main/java/com/spotify/ffwd/cache/NoopCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/NoopCache.java
@@ -28,7 +28,7 @@ import com.spotify.ffwd.model.Metric;
 public class NoopCache implements WriteCache {
 
   @Override
-  public boolean isCached(final Metric metric) {
+  public boolean checkCacheOrSet(final Metric metric) {
     return false;
   }
 

--- a/api/src/main/java/com/spotify/ffwd/cache/NoopCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/NoopCache.java
@@ -2,7 +2,7 @@
  * -\-\-
  * FastForward API
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,18 @@
  * -/-/-
  */
 
-package com.spotify.ffwd.serializer;
+package com.spotify.ffwd.cache;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.ffwd.cache.WriteCache;
-import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import java.util.Collection;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public interface Serializer {
-    byte[] serialize(Event event) throws Exception;
+/**
+ * Noop implementation of a WriteCache for when its disabled.
+ */
+public class NoopCache implements WriteCache {
 
-    byte[] serialize(Metric metric) throws Exception;
+  @Override
+  public boolean isCached(final Metric metric) {
+    return false;
+  }
 
-    byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception;
 }

--- a/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
@@ -24,7 +24,7 @@ import com.spotify.ffwd.model.Metric;
 
 public interface WriteCache {
 
-  // Check to see if a metric is cached locally. If not present set it,
-  boolean isCached(final Metric metric);
+  // Check to see if a metric is cached locally. If not present, set it.
+  boolean checkCacheOrSet(final Metric metric);
 
 }

--- a/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
@@ -24,7 +24,7 @@ import com.spotify.ffwd.model.Metric;
 
 public interface WriteCache {
 
-  // Check to see if a metric is cached locally
+  // Check to see if a metric is cached locally. If not present set it,
   boolean isCached(final Metric metric);
 
 }

--- a/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
+++ b/api/src/main/java/com/spotify/ffwd/cache/WriteCache.java
@@ -1,8 +1,8 @@
 /*-
  * -\-\-
- * FastForward API
+ * FastForward Pubsub Module
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,13 @@
  * -/-/-
  */
 
-package com.spotify.ffwd.serializer;
+package com.spotify.ffwd.cache;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.ffwd.cache.WriteCache;
-import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
-import java.util.Collection;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public interface Serializer {
-    byte[] serialize(Event event) throws Exception;
+public interface WriteCache {
 
-    byte[] serialize(Metric metric) throws Exception;
+  // Check to see if a metric is cached locally
+  boolean isCached(final Metric metric);
 
-    byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception;
 }

--- a/api/src/main/java/com/spotify/ffwd/model/Metric.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Metric.java
@@ -20,6 +20,10 @@
 
 package com.spotify.ffwd.model;
 
+import com.google.common.base.Charsets;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +36,8 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(of = {"key", "riemannTags", "tags"})
 public class Metric {
+    static final HashFunction HASH_FUNCTION = Hashing.murmur3_128();
+
     private final String key;
     private final double value;
     private final Date time;
@@ -48,4 +54,28 @@ public class Metric {
     public Batch.Point toBatchPoint() {
         return new Batch.Point(key, tags, resource, value, time.getTime());
     }
+
+    public String generateHash() {
+        final Hasher hasher = HASH_FUNCTION.newHasher();
+
+        if (key != null) {
+            hasher.putString(key, Charsets.UTF_8);
+        }
+
+        for (final Map.Entry<String, String> kv : tags.entrySet()) {
+            final String k = kv.getKey();
+            final String v = kv.getValue();
+
+            if (k != null) {
+                hasher.putString(k, Charsets.UTF_8);
+            }
+
+            if (v != null) {
+                hasher.putString(v, Charsets.UTF_8);
+            }
+        }
+
+        return hasher.hash().toString();
+    }
+
 }

--- a/api/src/main/java/com/spotify/ffwd/model/Metric.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Metric.java
@@ -43,8 +43,8 @@ public class Metric {
     private final double value;
     private final Date time;
     private final Set<String> riemannTags;
-    private final TreeMap<String, String> tags;
-    private final TreeMap<String, String> resource;
+    private final Map<String, String> tags;
+    private final Map<String, String> resource;
     private final String proc;
 
     /**
@@ -62,8 +62,9 @@ public class Metric {
         if (key != null) {
             hasher.putString(key, Charsets.UTF_8);
         }
+        TreeMap<String, String> sortedTags = new TreeMap<>(tags);
 
-        for (final Map.Entry<String, String> kv : tags.entrySet()) {
+        for (final Map.Entry<String, String> kv : sortedTags.entrySet()) {
             final String k = kv.getKey();
             final String v = kv.getValue();
 

--- a/api/src/main/java/com/spotify/ffwd/model/Metric.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Metric.java
@@ -27,6 +27,7 @@ import com.google.common.hash.Hashing;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -42,8 +43,8 @@ public class Metric {
     private final double value;
     private final Date time;
     private final Set<String> riemannTags;
-    private final Map<String, String> tags;
-    private final Map<String, String> resource;
+    private final TreeMap<String, String> tags;
+    private final TreeMap<String, String> resource;
     private final String proc;
 
     /**

--- a/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -20,7 +20,11 @@
 
 package com.spotify.ffwd.statistics;
 
+import com.codahale.metrics.Metric;
+import com.spotify.metrics.core.MetricId;
 import eu.toolchain.async.FutureFinished;
+import java.util.Collections;
+import java.util.Map;
 
 public class NoopCoreStatistics implements CoreStatistics {
     private static final InputManagerStatistics noopInputManagerStatistics =
@@ -79,7 +83,19 @@ public class NoopCoreStatistics implements CoreStatistics {
         return noopOutputManagerStatistics;
     }
 
-    private static final OutputPluginStatistics noopOutputPluginStatistics = dropped -> { };
+    private static final OutputPluginStatistics noopOutputPluginStatistics =
+        new OutputPluginStatistics() {
+          @Override
+          public Map<MetricId, Metric> getMetrics() {
+            return Collections.emptyMap();
+          }
+
+          @Override
+          public void reportDropped(int dropped) { }
+
+          @Override
+          public void registerCacheStats(SemanticCacheStatistics stats) { }
+        };
 
     @Override
     public OutputPluginStatistics newOutputPlugin(String id) {

--- a/api/src/main/java/com/spotify/ffwd/statistics/OutputPluginStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/OutputPluginStatistics.java
@@ -20,11 +20,19 @@
 
 package com.spotify.ffwd.statistics;
 
-public interface OutputPluginStatistics {
-    /**
-     * Report that a number of events and metrics have been dropped.
-     *
-     * @param dropped The number of events and metrics that we have dropped.
-     */
-    void reportDropped(int dropped);
+import com.spotify.metrics.core.SemanticMetricSet;
+
+public interface OutputPluginStatistics extends SemanticMetricSet {
+  /**
+   * Report that a number of events and metrics have been dropped.
+   *
+   * @param dropped The number of events and metrics that we have dropped.
+   */
+  void reportDropped(int dropped);
+
+  /**
+   * Register cache stats. This is a bit of a leaky abstraction. Adding metrics to the cache is
+   * difficult.
+   */
+  void registerCacheStats(SemanticCacheStatistics stats);
 }

--- a/api/src/main/java/com/spotify/ffwd/statistics/SemanticCacheStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/SemanticCacheStatistics.java
@@ -1,0 +1,58 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.statistics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.google.common.cache.Cache;
+import com.spotify.metrics.core.MetricId;
+import com.spotify.metrics.core.SemanticMetricSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Semantic guava cache statistics. All the metrics except size are actually counters but we
+ * register them as gauges in order to cut down on the logic needed to track counters being
+ * incremented. Semantic-metrics will add a metric-type tag of gauge that will be wrong. At some
+ * point semantic-metrics should be changed to preserve the metric-type tag if it exists.
+ */
+public class SemanticCacheStatistics implements SemanticMetricSet {
+  private final Cache cache;
+
+  public SemanticCacheStatistics(final Cache cache) {
+    this.cache = cache;
+  }
+
+  @Override
+  public Map<MetricId, Metric> getMetrics() {
+    final Map<MetricId, Metric> gauges = new HashMap<>();
+    final MetricId m = MetricId.EMPTY.tagged("subcomponent", "cache");
+
+    gauges.put(m.tagged("what", "hit-count"), (Gauge<Long>) () -> cache.stats().hitCount());
+    gauges.put(m.tagged("what", "miss-count"), (Gauge<Long>) () -> cache.stats().missCount());
+    gauges.put(
+        m.tagged("what", "eviction-count"), (Gauge<Long>) () -> cache.stats().evictionCount());
+    gauges.put(m.tagged("what", "size"), (Gauge<Long>) cache::size);
+
+    return Collections.unmodifiableMap(gauges);
+  }
+}

--- a/api/src/test/java/com/spotify/ffwd/Utils.java
+++ b/api/src/test/java/com/spotify/ffwd/Utils.java
@@ -1,8 +1,8 @@
 /*-
  * -\-\-
- * FastForward API
+ * FastForward Pubsub Module
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,18 @@
  * limitations under the License.
  * -/-/-
  */
+package com.spotify.ffwd;
 
-package com.spotify.ffwd.serializer;
-
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.ffwd.cache.WriteCache;
-import com.spotify.ffwd.model.Event;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.spotify.ffwd.model.Metric;
-import java.util.Collection;
+import java.util.Date;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public interface Serializer {
-    byte[] serialize(Event event) throws Exception;
+public class Utils {
 
-    byte[] serialize(Metric metric) throws Exception;
+  public static Metric makeMetric() {
+    return new Metric("key1", 1278, new Date(), ImmutableSet.of(),
+      ImmutableMap.of("what", "test"), ImmutableMap.of(), null);
+  }
 
-    byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception;
 }

--- a/api/src/test/java/com/spotify/ffwd/cache/ExpiringCacheTest.java
+++ b/api/src/test/java/com/spotify/ffwd/cache/ExpiringCacheTest.java
@@ -1,0 +1,42 @@
+/*-
+ * -\-\-
+ * FastForward API
+ * --
+ * Copyright (C) 2016 - 2019 Spotify AB
+ * --
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -/-/-
+ */
+
+package com.spotify.ffwd.cache;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.spotify.ffwd.Utils;
+import java.time.Duration;
+import org.junit.Test;
+
+public class ExpiringCacheTest {
+
+  @Test
+  public void testIsCached() {
+    final Cache<String, Boolean> cache =
+      CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
+    final WriteCache expiringCache = new ExpiringCache(cache);
+    assertFalse(expiringCache.isCached(Utils.makeMetric()));
+    assertTrue(expiringCache.isCached(Utils.makeMetric()));
+  }
+}

--- a/api/src/test/java/com/spotify/ffwd/cache/ExpiringCacheTest.java
+++ b/api/src/test/java/com/spotify/ffwd/cache/ExpiringCacheTest.java
@@ -36,7 +36,7 @@ public class ExpiringCacheTest {
     final Cache<String, Boolean> cache =
       CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(1)).build();
     final WriteCache expiringCache = new ExpiringCache(cache);
-    assertFalse(expiringCache.isCached(Utils.makeMetric()));
-    assertTrue(expiringCache.isCached(Utils.makeMetric()));
+    assertFalse(expiringCache.checkCacheOrSet(Utils.makeMetric()));
+    assertTrue(expiringCache.checkCacheOrSet(Utils.makeMetric()));
   }
 }

--- a/api/src/test/java/com/spotify/ffwd/cache/NoopTest.java
+++ b/api/src/test/java/com/spotify/ffwd/cache/NoopTest.java
@@ -29,7 +29,7 @@ public class NoopTest {
 
   @Test
   public void testIsCached() {
-    assertFalse(new NoopCache().isCached(Utils.makeMetric()));
+    assertFalse(new NoopCache().checkCacheOrSet(Utils.makeMetric()));
   }
 
 }

--- a/api/src/test/java/com/spotify/ffwd/cache/NoopTest.java
+++ b/api/src/test/java/com/spotify/ffwd/cache/NoopTest.java
@@ -2,7 +2,7 @@
  * -\-\-
  * FastForward API
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,18 @@
  * -/-/-
  */
 
-package com.spotify.ffwd.serializer;
+package com.spotify.ffwd.cache;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.ffwd.cache.WriteCache;
-import com.spotify.ffwd.model.Event;
-import com.spotify.ffwd.model.Metric;
-import java.util.Collection;
+import static org.junit.Assert.assertFalse;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-public interface Serializer {
-    byte[] serialize(Event event) throws Exception;
+import com.spotify.ffwd.Utils;
+import org.junit.Test;
 
-    byte[] serialize(Metric metric) throws Exception;
+public class NoopTest {
 
-    byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception;
+  @Test
+  public void testIsCached() {
+    assertFalse(new NoopCache().isCached(Utils.makeMetric()));
+  }
+
 }

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
@@ -50,7 +50,7 @@ public class Spotify100ProtoSerializer implements Serializer {
     final Spotify100.Batch.Builder batch = Spotify100.Batch.newBuilder();
 
     for (Metric metric : metrics) {
-      if (!writeCache.isCached(metric)) {
+      if (!writeCache.checkCacheOrSet(metric)) {
         batch.addMetric(serializeMetric(metric));
       }
     }

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
@@ -20,11 +20,11 @@
 
 package com.spotify.ffwd.serializer;
 
+import com.spotify.ffwd.cache.WriteCache;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import com.spotify.proto.Spotify100;
 import java.util.Collection;
-import lombok.extern.slf4j.Slf4j;
 import org.xerial.snappy.Snappy;
 
 /**
@@ -34,12 +34,9 @@ import org.xerial.snappy.Snappy;
  *
  * Compression is done with the snappy library via JNI.
  */
-@Slf4j
 public class Spotify100ProtoSerializer implements Serializer {
-
   @Override
   public byte[] serialize(final Event event) throws Exception {
-    log.debug("Serializing events is not supported");
     return new byte[0];
   }
 
@@ -49,13 +46,14 @@ public class Spotify100ProtoSerializer implements Serializer {
   }
 
   @Override
-  public byte[] serialize(final Collection<Metric> metrics) throws Exception {
+  public byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception {
     final Spotify100.Batch.Builder batch = Spotify100.Batch.newBuilder();
 
     for (Metric metric : metrics) {
-      batch.addMetric(serializeMetric(metric));
+      if (!writeCache.isCached(metric)) {
+        batch.addMetric(serializeMetric(metric));
+      }
     }
-
     return Snappy.compress(batch.build().toByteArray());
   }
 

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.spotify.ffwd.cache.WriteCache;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import java.util.Collection;
@@ -80,7 +81,7 @@ public class Spotify100Serializer implements Serializer {
     }
 
     @Override
-    public byte[] serialize(Collection<Metric> metrics) throws Exception {
+    public byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception {
         throw new UnsupportedOperationException("Not supported");
     }
 }

--- a/core/src/main/java/com/spotify/ffwd/serializer/ToStringSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/ToStringSerializer.java
@@ -21,6 +21,7 @@
 package com.spotify.ffwd.serializer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.spotify.ffwd.cache.WriteCache;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
 import java.util.Collection;
@@ -45,7 +46,7 @@ public class ToStringSerializer implements Serializer {
     }
 
     @Override
-    public byte[] serialize(Collection<Metric> metrics) throws Exception {
+    public byte[] serialize(Collection<Metric> metrics, WriteCache writeCache) throws Exception {
         throw new UnsupportedOperationException("Not supported");
     }
 

--- a/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
+++ b/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.spotify.ffwd.cache.NoopCache;
 import com.spotify.ffwd.model.Metric;
 import java.time.Instant;
 import java.util.Date;
@@ -35,6 +36,8 @@ import org.junit.Test;
 public class TestSpotify100ProtoSerializer {
   private Serializer serializer;
   private Metric metric1;
+
+  private static NoopCache writeCache = new NoopCache();
 
   @Before
   public void setup() {
@@ -64,7 +67,7 @@ public class TestSpotify100ProtoSerializer {
       ImmutableMap.of(),
       "");
 
-    serializer.serialize(ImmutableList.of(metric1));
+    serializer.serialize(ImmutableList.of(metric1), writeCache);
   }
 
   @Test
@@ -84,7 +87,7 @@ public class TestSpotify100ProtoSerializer {
       ImmutableMap.of("resource-a", "bar"),
       "");
 
-    final byte[] serialize = serializer.serialize(ImmutableList.of(metric1, metric2));
+    final byte[] serialize = serializer.serialize(ImmutableList.of(metric1, metric2), writeCache);
 
     assertThat(serialize, is(
       new byte[]{93, -120, 10, 40, 16, -64, -37, -106, -74, -13, 44, 34, 12, 10, 5, 116, 97, 103,

--- a/docs/content/_docs/pubsub.md
+++ b/docs/content/_docs/pubsub.md
@@ -22,14 +22,33 @@ based on request size, message count and time since last publish. The client by 
 
 
 Here is an example config of setting up the pubsub plugin.
+
 ```
 output:
   plugins:
     - type: pubsub
-      flushInterval: 10000
       project: google-test-project
       topic: test-topic
+      serializer:
+        type: spotify100proto
+      
+      batching:
+        flushInterval: 10000
+        batchSizeLimit: 10000  # Default: 10000
+        maxPendingFlushes: 10 # Default: 10 
 ```
+
+
+### Write Cache
+
+There is an optional write cache that can be enabled. At Spotify this is being used as a "cheap" method
+to deduplicate the metadata around timeseries when using the heroic tsbd. The way this feature is used is by publishing from ffwd twice. 
+Once for "metrics" that get written to bigtable every batch interval and another for metadata and suggestion writes to elasticsearch. Only the metadata publisher would
+enabled the write cache. This would only publish metadata every cacheDuration.
+
+* `writeCacheEnabled` - defaults false
+* `writeCacheDurationMinutes` - defaults to 30 minutes
+* `writeCacheMaxSize` - defaults to 10,000
 
 
 ## Authentication

--- a/docs/content/_docs/pubsub.md
+++ b/docs/content/_docs/pubsub.md
@@ -42,12 +42,11 @@ output:
 ### Write Cache
 
 There is an optional write cache that can be enabled. At Spotify this is being used as a "cheap" method
-to deduplicate the metadata around timeseries when using the heroic tsbd. The way this feature is used is by publishing from ffwd twice. 
-Once for "metrics" that get written to bigtable every batch interval and another for metadata and suggestion writes to elasticsearch. Only the metadata publisher would
-enabled the write cache. This would only publish metadata every cacheDuration.
+to deduplicate the metadata around timeseries when using the Heroic TSDB. The way this feature is used is by publishing from ffwd twice. 
+Once for "metrics" that get written to bigtable every batch interval and another for metadata and suggestion 
+writes to elasticsearch. Only the metadata publisher would enabled the write cache. This would only publish metadata every cacheDuration.
 
-* `writeCacheEnabled` - defaults false
-* `writeCacheDurationMinutes` - defaults to 30 minutes
+* `writeCacheDurationMinutes` - defaults to 0 minutes - which disables the write cache
 * `writeCacheMaxSize` - defaults to 10,000
 
 

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -24,7 +24,6 @@
             <groupId>com.spotify.ffwd</groupId>
             <artifactId>ffwd-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.spotify.ffwd</groupId>
             <artifactId>ffwd-core</artifactId>

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
@@ -33,6 +33,8 @@ import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -40,6 +42,9 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import com.google.pubsub.v1.ProjectTopicName;
+import com.spotify.ffwd.cache.ExpiringCache;
+import com.spotify.ffwd.cache.NoopCache;
+import com.spotify.ffwd.cache.WriteCache;
 import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.module.Batching;
 import com.spotify.ffwd.output.OutputPlugin;
@@ -59,11 +64,19 @@ public class PubsubOutputPlugin extends OutputPlugin {
   private static final long DEFAULT_COUNT_THRESHOLD = 1000L;
   private static final long DEFAULT_DELAY_THRESHOLD = Duration.ofMillis(200).toMillis();
 
+  private static final boolean DEFAULT_CACHE_ENABLED = false;
+  private static final long DEFAULT_CACHE_MINUTES = 30L;
+  private static final long DEFAULT_CACHE_MAX_SIZE = 50_000L; // roughly 7.2 MB of memory
+
   private final Optional<Serializer> serializer;
 
   private final Optional<String> serviceAccount;
   private final Optional<String> project;
   private final Optional<String> topic;
+
+  private final boolean writeCacheEnabled;
+  private final long writeCacheDurationMinutes;
+  private final long writeCacheMaxSize;
 
   private final long requestBytesThreshold;
   private final long messageCountBatchSize;
@@ -80,6 +93,10 @@ public class PubsubOutputPlugin extends OutputPlugin {
     @JsonProperty("project") String project,
     @JsonProperty("topic") String topic,
 
+    @JsonProperty("writeCacheEnabled") Boolean writeCacheEnabled,
+    @JsonProperty("writeCacheDurationMinutes") Long writeCacheDurationMinutes,
+    @JsonProperty("writeCacheMaxSize") Long writeCacheMaxSize,
+
     @JsonProperty("requestBytesThreshold") Long requestBytesThreshold,
     @JsonProperty("messageCountBatchSize") Long messageCountBatchSize,
     @JsonProperty("publishDelayThresholdMs") Long publishDelayThresholdMs
@@ -90,6 +107,11 @@ public class PubsubOutputPlugin extends OutputPlugin {
     this.serviceAccount = ofNullable(serviceAccount);
     this.project = ofNullable(project);
     this.topic = ofNullable(topic);
+
+    this.writeCacheEnabled = ofNullable(writeCacheEnabled).orElse(DEFAULT_CACHE_ENABLED);
+    this.writeCacheDurationMinutes =
+        ofNullable(writeCacheDurationMinutes).orElse(DEFAULT_CACHE_MINUTES);
+    this.writeCacheMaxSize = ofNullable(writeCacheMaxSize).orElse(DEFAULT_CACHE_MAX_SIZE);
 
     this.requestBytesThreshold = ofNullable(requestBytesThreshold).orElse(DEFAULT_BYTES_THRESHOLD);
     this.messageCountBatchSize = ofNullable(messageCountBatchSize).orElse(DEFAULT_COUNT_THRESHOLD);
@@ -113,25 +135,27 @@ public class PubsubOutputPlugin extends OutputPlugin {
       @Singleton
       public Publisher publisher() throws IOException {
         // Publish request based on request size, messages count & time since last publish
-        BatchingSettings batchingSettings = BatchingSettings.newBuilder()
-          .setElementCountThreshold(messageCountBatchSize)
-          .setRequestByteThreshold(requestBytesThreshold)
-          .setDelayThreshold(publishDelayThreshold)
-          .build();
+        BatchingSettings batchingSettings =
+            BatchingSettings.newBuilder()
+                .setElementCountThreshold(messageCountBatchSize)
+                .setRequestByteThreshold(requestBytesThreshold)
+                .setDelayThreshold(publishDelayThreshold)
+                .build();
 
-        ExecutorProvider executorProvider = InstantiatingExecutorProvider.newBuilder()
-          .setExecutorThreadCount(1).build();
+        ExecutorProvider executorProvider =
+            InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(1).build();
 
-        final Publisher.Builder publisher = Publisher.newBuilder(topicName())
-          .setBatchingSettings(batchingSettings)
-          .setExecutorProvider(executorProvider);
+        final Publisher.Builder publisher =
+            Publisher.newBuilder(topicName())
+                .setBatchingSettings(batchingSettings)
+                .setExecutorProvider(executorProvider);
 
         final String emulatorHost = System.getenv("PUBSUB_EMULATOR_HOST");
         if (emulatorHost != null) {
           ManagedChannel channel =
-            ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
+              ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
           TransportChannelProvider channelProvider =
-            FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+              FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
 
           publisher.setChannelProvider(channelProvider);
           publisher.setCredentialsProvider(NoCredentialsProvider.create());
@@ -140,6 +164,24 @@ public class PubsubOutputPlugin extends OutputPlugin {
         return publisher.build();
       }
 
+      @Provides
+      @Singleton
+      public Optional<Cache<String, Boolean>> cache() {
+        if (writeCacheEnabled) {
+          return Optional.of(CacheBuilder.newBuilder()
+              .expireAfterAccess(java.time.Duration.ofMinutes(writeCacheDurationMinutes))
+              .maximumSize(writeCacheMaxSize)
+              .recordStats()
+              .build());
+        }
+        return Optional.empty();
+      }
+
+      @Provides
+      @Singleton
+      public WriteCache writeCache(Optional<Cache<String, Boolean>> cache) {
+        return cache.<WriteCache>map(ExpiringCache::new).orElseGet(NoopCache::new);
+      }
 
       @Override
       protected void configure() {
@@ -150,7 +192,7 @@ public class PubsubOutputPlugin extends OutputPlugin {
         }
 
         final Key<PubsubPluginSink> sinkKey =
-          Key.get(PubsubPluginSink.class, Names.named("pubsubSink"));
+            Key.get(PubsubPluginSink.class, Names.named("pubsubSink"));
         bind(sinkKey).to(PubsubPluginSink.class).in(Scopes.SINGLETON);
         install(wrapPluginSink(sinkKey, key));
         expose(key);

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
@@ -64,8 +64,7 @@ public class PubsubOutputPlugin extends OutputPlugin {
   private static final long DEFAULT_COUNT_THRESHOLD = 1000L;
   private static final long DEFAULT_DELAY_THRESHOLD = Duration.ofMillis(200).toMillis();
 
-  private static final boolean DEFAULT_CACHE_ENABLED = false;
-  private static final long DEFAULT_CACHE_MINUTES = 30L;
+  private static final long DEFAULT_CACHE_MINUTES = 0L;
   private static final long DEFAULT_CACHE_MAX_SIZE = 50_000L; // roughly 7.2 MB of memory
 
   private final Optional<Serializer> serializer;
@@ -74,7 +73,6 @@ public class PubsubOutputPlugin extends OutputPlugin {
   private final Optional<String> project;
   private final Optional<String> topic;
 
-  private final boolean writeCacheEnabled;
   private final long writeCacheDurationMinutes;
   private final long writeCacheMaxSize;
 
@@ -93,7 +91,6 @@ public class PubsubOutputPlugin extends OutputPlugin {
     @JsonProperty("project") String project,
     @JsonProperty("topic") String topic,
 
-    @JsonProperty("writeCacheEnabled") Boolean writeCacheEnabled,
     @JsonProperty("writeCacheDurationMinutes") Long writeCacheDurationMinutes,
     @JsonProperty("writeCacheMaxSize") Long writeCacheMaxSize,
 
@@ -108,7 +105,6 @@ public class PubsubOutputPlugin extends OutputPlugin {
     this.project = ofNullable(project);
     this.topic = ofNullable(topic);
 
-    this.writeCacheEnabled = ofNullable(writeCacheEnabled).orElse(DEFAULT_CACHE_ENABLED);
     this.writeCacheDurationMinutes =
         ofNullable(writeCacheDurationMinutes).orElse(DEFAULT_CACHE_MINUTES);
     this.writeCacheMaxSize = ofNullable(writeCacheMaxSize).orElse(DEFAULT_CACHE_MAX_SIZE);
@@ -167,7 +163,7 @@ public class PubsubOutputPlugin extends OutputPlugin {
       @Provides
       @Singleton
       public Optional<Cache<String, Boolean>> cache() {
-        if (writeCacheEnabled) {
+        if (writeCacheDurationMinutes > 0) {
           return Optional.of(CacheBuilder.newBuilder()
               .expireAfterAccess(java.time.Duration.ofMinutes(writeCacheDurationMinutes))
               .maximumSize(writeCacheMaxSize)

--- a/modules/pubsub/src/test/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
+++ b/modules/pubsub/src/test/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
@@ -1,9 +1,12 @@
 package com.spotify.ffwd.pubsub;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -12,6 +15,8 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.spotify.ffwd.model.Batch;
 import com.spotify.ffwd.model.Event;
 import com.spotify.ffwd.model.Metric;
+import com.spotify.ffwd.cache.NoopCache;
+import com.spotify.ffwd.cache.WriteCache;
 import com.spotify.ffwd.serializer.ToStringSerializer;
 import eu.toolchain.async.AsyncFramework;
 import java.util.Date;
@@ -20,7 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PubsubPluginSinkTest {
@@ -39,29 +46,47 @@ public class PubsubPluginSinkTest {
         sink.async = async;
         sink.publisher = publisher;
         sink.serializer = new ToStringSerializer();
+        sink.writeCache = new NoopCache();
+        sink.logger = LoggerFactory.getLogger(PubsubPluginSinkTest.class);
+
     }
 
     private Event makeEvent() {
         return new Event("test_event", 1278, new Date(), 12L, "critical", "test_event", "test_host",
             ImmutableSet.of(), ImmutableMap.of("what", "stats", "pod", "gew1"));
     }
-    private Metric makeMetric() {
-        return new Metric("key1", 1278, new Date(), ImmutableSet.of(),
-                ImmutableMap.of("what", "test"), ImmutableMap.of(), null);
-    }
 
     @Test
     public void testSendEvent() {
         sink.sendEvent(makeEvent());
-        verify(publisher).publish(any(PubsubMessage.class));
+        verifyZeroInteractions(publisher);
     }
 
     @Test
     public void testSendMetric() {
+        when(publisher.publish(Mockito.any())).thenReturn(ApiFutures.immediateFuture("Sent"));
         sink.sendMetric(makeMetric());
-        verify(publisher).publish(any(PubsubMessage.class));
+        verify(publisher).publish(isA(PubsubMessage.class));
     }
 
+
+    @Test
+    public void testSendMetricCache() {
+        sink.writeCache = new WriteCache() {
+            @Override
+            public boolean isCached(Metric metric) {
+                return true;
+            }
+
+            @Override
+            public void remove(Metric metric) {
+
+            }
+        };
+        when(publisher.publish(Mockito.any())).thenReturn(ApiFutures.immediateFuture("Sent"));
+        sink.sendMetric(makeMetric());
+        verifyZeroInteractions(publisher);
+    }
 
     @Test
     public void testSendBatch() {
@@ -70,7 +95,7 @@ public class PubsubPluginSinkTest {
             ImmutableList.of(makeMetric().toBatchPoint()));
 
         sink.sendBatch(batch);
-        verify(publisher).publish(any(PubsubMessage.class));
+        verify(publisher).publish(isA(PubsubMessage.class));
     }
 
 }

--- a/modules/pubsub/src/test/com/spotify/ffwd/pubsub/Utils.java
+++ b/modules/pubsub/src/test/com/spotify/ffwd/pubsub/Utils.java
@@ -1,0 +1,14 @@
+package com.spotify.ffwd.pubsub;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.spotify.ffwd.model.Metric;
+import java.util.Date;
+
+public class Utils {
+
+  public static Metric makeMetric() {
+    return new Metric("key1", 1278, new Date(), ImmutableSet.of(),
+      ImmutableMap.of("what", "test"), ImmutableMap.of(), null);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <slf4j.version>1.7.25</slf4j.version>
     <jackson.version>2.9.8</jackson.version>
     <kotlin.version>1.3.31</kotlin.version>
+    <spotify-metrics.version>1.0.2</spotify-metrics.version>
   </properties>
 
   <profiles>
@@ -234,6 +235,19 @@
         <groupId>com.uchuhimo</groupId>
         <artifactId>konf</artifactId>
         <version>0.13.3</version>
+      </dependency>
+
+
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-core</artifactId>
+        <version>${spotify-metrics.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.spotify.metrics</groupId>
+        <artifactId>semantic-metrics-ffwd-reporter</artifactId>
+        <version>${spotify-metrics.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
An ExpiringCache is useful to reduce the number of metrics being published to a topic. Typically processing and de-deduplication of the "metadata" around a metric only needs to happen every so often. In the case of using Heroic, this "metadata" only needs to be published at the interval of a new index being created.

@sjoeboo @lmuhlha @hexedpackets 