### PR TITLE
Update configuration to load from yaml or env vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ release.properties
 
 # Documentation build
 /docs/_site/
+.pr-train.yml

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- semantic metrics -->
     <dependency>
@@ -119,6 +124,18 @@
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/agent/src/main/java/com/spotify/ffwd/FastForwardAgent.java
+++ b/agent/src/main/java/com/spotify/ffwd/FastForwardAgent.java
@@ -29,7 +29,6 @@ import com.spotify.metrics.jvm.GarbageCollectorMetricSet;
 import com.spotify.metrics.jvm.MemoryUsageGaugeSet;
 import com.spotify.metrics.jvm.ThreadStatesMetricSet;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -52,13 +51,11 @@ public class FastForwardAgent {
             path = Optional.of(Paths.get(argv[0]));
         }
 
-        final FastForwardAgent agent = setup(path, Optional.empty());
+        final FastForwardAgent agent = setup(path);
         run(agent);
     }
 
-    static FastForwardAgent setup(
-        final Optional<Path> configPath, final Optional<InputStream> configStream
-    ) {
+    static FastForwardAgent setup(final Optional<Path> configPath) {
         // needed for HTTP content decompression in:
         // com.spotify.ffwd.http.HttpModule
         System.setProperty("io.netty.noJdkZlibDecoder", "false");
@@ -102,12 +99,9 @@ public class FastForwardAgent {
         final AgentCore.Builder builder = AgentCore.builder()
             .modules(modules)
             .statistics(statistics.statistics);
-
-        configStream.map(builder::configStream);
         configPath.map(builder::configPath);
 
         final AgentCore core = builder.build();
-
         return new FastForwardAgent(statistics, core);
     }
 

--- a/agent/src/test/resources/basic-settings.yaml
+++ b/agent/src/test/resources/basic-settings.yaml
@@ -1,0 +1,2 @@
+ttl: 50
+host: jimjam

--- a/agent/src/test/resources/invalid.yaml
+++ b/agent/src/test/resources/invalid.yaml
@@ -1,0 +1,3 @@
+unknown_fake_property: true
+
+host: jimjam

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,10 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib-jdk8</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.uchuhimo</groupId>
+      <artifactId>konf</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -2,7 +2,7 @@
  * -\-\-
  * FastForward Core
  * --
- * Copyright (C) 2016 - 2018 Spotify AB
+ * Copyright (C) 2016 - 2019 Spotify AB
  * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,12 +42,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 public class CoreOutputManager implements OutputManager {
     private static final String DEBUG_ID = "core.output";
     private static final String HOST = "host";
+    private static final Logger log = LoggerFactory.getLogger(CoreOutputManager.class);
 
     @Inject
     @Getter
@@ -84,9 +85,17 @@ public class CoreOutputManager implements OutputManager {
     @Named("host")
     private String host;
 
+    public String getHost() {
+        return host;
+    }
+
     @Inject
     @Named("ttl")
     private long ttl;
+
+    public long getTtl() {
+        return ttl;
+    }
 
     @Inject
     private DebugServer debug;

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>ffwd-module-pubsub</artifactId>
-  <version>0.4.12-SNAPSHOT</version>
+    <version>0.4.12-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>FastForward Pubsub Module</name>
 
@@ -51,18 +51,18 @@
             <version>27.0.1-jre</version>
         </dependency>
 
-      <!-- testing -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <scope>test</scope>
-      </dependency>
+        <!-- testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,6 +90,17 @@
                                     <exclude>io.netty:*</exclude>
                                 </excludes>
                             </artifactSet>
+
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
 
                             <relocations>
                                 <!-- move protobuf to a shaded package -->

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
         <artifactId>kotlin-stdlib-jdk8</artifactId>
         <version>${kotlin.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.uchuhimo</groupId>
+        <artifactId>konf</artifactId>
+        <version>0.13.3</version>
+      </dependency>
 
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -355,8 +360,22 @@
         <version>1.9.5</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.github.stefanbirkner</groupId>
+        <artifactId>system-rules</artifactId>
+        <version>1.19.0</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <extensions>


### PR DESCRIPTION
Env vars are the preferred way to configure ffwd when its running in kubernetes, and will be needed for #132 

This also fixes #120 since the Konf library ignores unknowns by default.