### PR TITLE
Enable rate limiting in the output manager.

### DIFF
--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -97,13 +97,17 @@ public class SemanticCoreStatistics implements CoreStatistics {
 
         return new OutputManagerStatistics() {
             private final Meter sentMetrics =
-                registry.meter(m.tagged("what", "sent-metrics", "unit", "metric"));
+              registry.meter(m.tagged("what", "sent-metrics", "unit", "metric"));
             private final Meter sentEvents =
-                registry.meter(m.tagged("what", "sent-events", "unit", "event"));
-            private final Meter metricsDroppedByFilter =
-                registry.meter(m.tagged("what", "metrics-dropped-by-filter", "unit", "metric"));
+              registry.meter(m.tagged("what", "sent-events", "unit", "event"));
             private final Meter eventsDroppedByFilter =
-                registry.meter(m.tagged("what", "events-dropped-by-filter", "unit", "event"));
+              registry.meter(m.tagged("what", "events-dropped-by-filter", "unit", "event"));
+            private final Meter eventsDroppedByRateLimit =
+              registry.meter(m.tagged("what", "events-dropped-by-ratelimit", "unit", "metric"));
+            private final Meter metricsDroppedByFilter =
+              registry.meter(m.tagged("what", "metrics-dropped-by-filter", "unit", "metric"));
+            private final Meter metricsDroppedByRateLimit =
+              registry.meter(m.tagged("what", "metrics-dropped-by-ratelimit", "unit", "metric"));
 
             @Override
             public void reportSentMetrics(int sent) {
@@ -121,8 +125,18 @@ public class SemanticCoreStatistics implements CoreStatistics {
             }
 
             @Override
+            public void reportEventsDroppedByRateLimit(final int dropped) {
+                eventsDroppedByRateLimit.mark(dropped);
+            }
+
+            @Override
             public void reportMetricsDroppedByFilter(int dropped) {
                 metricsDroppedByFilter.mark(dropped);
+            }
+
+            @Override
+            public void reportMetricsDroppedByRateLimit(int dropped) {
+                metricsDroppedByRateLimit.mark(dropped);
             }
         };
     }

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -93,8 +93,12 @@ public class FfwdConfigurationTest {
     @Test
     public void testConfigFromEnvVars() {
         environmentVariables.set("FFWD_TTL", "100");
+        environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
+
         CoreOutputManager outputManager = getOutputManager(null);
+
         assertEquals(100, outputManager.getTtl());
+        assertEquals(Integer.valueOf(1000), outputManager.getRateLimit());
     }
 
     @Test

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -98,7 +98,7 @@ public class FfwdConfigurationTest {
         CoreOutputManager outputManager = getOutputManager(null);
 
         assertEquals(100, outputManager.getTtl());
-        assertEquals(Integer.valueOf(1000), outputManager.getRateLimit());
+        assertEquals(Double.valueOf(1000), outputManager.getRateLimit());
     }
 
     @Test

--- a/api/src/main/java/com/spotify/ffwd/module/Batching.java
+++ b/api/src/main/java/com/spotify/ffwd/module/Batching.java
@@ -23,13 +23,14 @@ package com.spotify.ffwd.module;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import lombok.Data;
 
 @Data
 public class Batching {
     public static final boolean DEFAULT_REPORT_STATISTICS = false;
 
-    protected final Optional<Long> flushInterval;
+    @Nullable protected final Long flushInterval;
     protected final Optional<Long> batchSizeLimit;
     protected final Optional<Long> maxPendingFlushes;
 
@@ -40,7 +41,7 @@ public class Batching {
 
     @JsonCreator
     public Batching(
-        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("flushInterval") @Nullable Long flushInterval,
         @JsonProperty("batchSizeLimit") Optional<Long> batchSizeLimit,
         @JsonProperty("maxPendingFlushes") Optional<Long> maxPendingFlushes,
         @JsonProperty("reportStatistics") Optional<Boolean> reportStatistics
@@ -49,16 +50,6 @@ public class Batching {
         this.batchSizeLimit = batchSizeLimit;
         this.maxPendingFlushes = maxPendingFlushes;
         this.reportStatistics = reportStatistics.orElse(DEFAULT_REPORT_STATISTICS);
-    }
-
-    public static Batching empty() {
-        return from(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
-    public static Batching from(
-        final Optional<Long> flushInterval, final Optional<Batching> batching
-    ) {
-        return from(flushInterval, batching, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -74,34 +65,15 @@ public class Batching {
      * This only contains something when the user didn't use any 'batching' sub structure in the
      * configuration, and just specified flushInterval.
      * @param batching A complete Batching structure, on the output plugin level in the conf.
-     * @param defaultFlushInterval Optional default value to be used if no flushInterval nor
      * batching was specified.
      * @return A Batching object.
      */
     public static Batching from(
-        final Optional<Long> flushInterval, final Optional<Batching> batching,
-        final Optional<Long> defaultFlushInterval
+        @Nullable final Long flushInterval,
+        final Optional<Batching> batching
     ) {
-        return from(flushInterval, batching, defaultFlushInterval, Optional.empty());
-    }
-
-    public static Batching from(
-        final Optional<Long> flushInterval, final Optional<Batching> batching,
-        final Optional<Long> defaultFlushInterval, final Optional<Boolean> reportStatistics
-    ) {
-        if (flushInterval.isPresent() && batching.isPresent()) {
-            throw new RuntimeException(
-                "Can't have both 'batching' and 'flushInterval' on the same level in the " +
-                    "configuration. Maybe move 'flushInterval' into 'batching'?");
-        }
-        if (batching.isPresent()) {
-            return batching.get();
-        }
-        if (flushInterval.isPresent()) {
-            return new Batching(flushInterval, Optional.empty(), Optional.empty(),
-                Optional.empty());
-        }
-        return new Batching(defaultFlushInterval, Optional.empty(), Optional.empty(),
-            Optional.empty());
+        return batching.orElseGet(
+          () -> new Batching(flushInterval, Optional.empty(), Optional.empty(), Optional.empty())
+        );
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/module/Batching.java
+++ b/api/src/main/java/com/spotify/ffwd/module/Batching.java
@@ -65,7 +65,6 @@ public class Batching {
      * This only contains something when the user didn't use any 'batching' sub structure in the
      * configuration, and just specified flushInterval.
      * @param batching A complete Batching structure, on the output plugin level in the conf.
-     * batching was specified.
      * @return A Batching object.
      */
     public static Batching from(

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
@@ -81,7 +81,7 @@ public abstract class OutputPlugin {
             protected void configure() {
                 Key<PluginSink> sinkKey = (Key<PluginSink>) input;
 
-                if (batching.getFlushInterval().isPresent() &&
+                if (batching.getFlushInterval() != null &&
                     BatchablePluginSink.class.isAssignableFrom(
                         input.getTypeLiteral().getRawType())) {
                     final Key<PluginSink> flushingKey =
@@ -95,7 +95,7 @@ public abstract class OutputPlugin {
                         .annotatedWith(BatchingDelegate.class)
                         .to(batchedPluginSink);
                     bind(flushingKey).toInstance(
-                        new BatchingPluginSink(batching.getFlushInterval().get(),
+                        new BatchingPluginSink(batching.getFlushInterval(),
                             batching.getBatchSizeLimit(), batching.getMaxPendingFlushes()));
 
                     sinkKey = flushingKey;

--- a/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
+++ b/api/src/main/java/com/spotify/ffwd/output/OutputPlugin.java
@@ -21,7 +21,6 @@
 package com.spotify.ffwd.output;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.google.inject.Key;
 import com.google.inject.Module;
@@ -38,7 +37,7 @@ import com.spotify.ffwd.statistics.NoopCoreStatistics;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-@JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type")
+@JsonTypeInfo(use = Id.NAME, property = "type")
 public abstract class OutputPlugin {
 
     protected final Batching batching;
@@ -79,6 +78,7 @@ public abstract class OutputPlugin {
         return new PrivateModule() {
             @Override
             protected void configure() {
+                @SuppressWarnings("unchecked")
                 Key<PluginSink> sinkKey = (Key<PluginSink>) input;
 
                 if (batching.getFlushInterval() != null &&
@@ -87,6 +87,7 @@ public abstract class OutputPlugin {
                     final Key<PluginSink> flushingKey =
                         Key.get(PluginSink.class, Names.named("flushing"));
                     // IDEA doesn't like this cast, but it's correct, tho admittedly not pretty
+                    @SuppressWarnings({"RedundantCast", "unchecked"})
                     final Key<? extends BatchablePluginSink> batchedPluginSink =
                         (Key<? extends BatchablePluginSink>) (Key<? extends PluginSink>) sinkKey;
 

--- a/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -79,7 +79,7 @@ public class NoopCoreStatistics implements CoreStatistics {
         return noopOutputManagerStatistics;
     }
 
-    private static final OutputPluginStatistics noopOutputPluginStatistics = dropped -> {};
+    private static final OutputPluginStatistics noopOutputPluginStatistics = dropped -> { };
 
     @Override
     public OutputPluginStatistics newOutputPlugin(String id) {

--- a/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/NoopCoreStatistics.java
@@ -62,7 +62,15 @@ public class NoopCoreStatistics implements CoreStatistics {
             }
 
             @Override
+            public void reportEventsDroppedByRateLimit(int dropped) {
+            }
+
+            @Override
             public void reportMetricsDroppedByFilter(int dropped) {
+            }
+
+            @Override
+            public void reportMetricsDroppedByRateLimit(final int dropped) {
             }
         };
 
@@ -71,12 +79,7 @@ public class NoopCoreStatistics implements CoreStatistics {
         return noopOutputManagerStatistics;
     }
 
-    private static final OutputPluginStatistics noopOutputPluginStatistics =
-        new OutputPluginStatistics() {
-            @Override
-            public void reportDropped(int dropped) {
-            }
-        };
+    private static final OutputPluginStatistics noopOutputPluginStatistics = dropped -> {};
 
     @Override
     public OutputPluginStatistics newOutputPlugin(String id) {

--- a/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
@@ -26,30 +26,48 @@ public interface OutputManagerStatistics {
      *
      * @param sent The number of metrics sent.
      */
-    public void reportSentEvents(int sent);
+    void reportSentEvents(int sent);
 
     /**
      * Report that the given number of metrics have been sent to output plugins.
      *
      * @param sent The number of metrics sent.
      */
-    public void reportSentMetrics(int sent);
+    void reportSentMetrics(int sent);
 
     /**
      * Reported that the given number of events were filtered.
      * <p>
      * Filtered events are <em>not</em> sent to output plugins.
      *
-     * @param filtered The number of filtered events.
+     * @param dropped The number of filtered events.
      */
-    public void reportEventsDroppedByFilter(int dropped);
+    void reportEventsDroppedByFilter(int dropped);
+
+    /**
+     * Reported that the given number of events were dropped due to a rate limit.
+     * <p>
+     * Dropped events are <em>not</em> sent to output plugins.
+     *
+     * @param dropped The number of dropped events.
+     */
+    void reportEventsDroppedByRateLimit(int dropped);
 
     /**
      * Reported that the given number of metrics were filtered.
      * <p>
      * Filtered metrics are <em>not</em> sent to output plugins.
      *
-     * @param filtered The number of filtered metrics.
+     * @param dropped The number of filtered metrics.
      */
-    public void reportMetricsDroppedByFilter(int dropped);
+    void reportMetricsDroppedByFilter(int dropped);
+
+    /**
+     * Reported that the given number of metrics were dropped due to a rate limit.
+     * <p>
+     * Dropped metrics are <em>not</em> sent to output plugins.
+     *
+     * @param dropped The number of dropped metrics.
+     */
+    void reportMetricsDroppedByRateLimit(int dropped);
 }

--- a/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/debug/DebugOutputPlugin.java
@@ -45,7 +45,7 @@ public class DebugOutputPlugin extends OutputPlugin {
         @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("filter") Optional<Filter> filter
     ) {
-        super(filter, Batching.from(flushInterval, batching, Optional.of(DEFAULT_FLUSH_INTERVAL)));
+        super(filter, Batching.from(flushInterval.orElse(DEFAULT_FLUSH_INTERVAL), batching));
     }
 
     @Override

--- a/core/src/main/java/com/spotify/ffwd/noop/NoopOutputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/noop/NoopOutputPlugin.java
@@ -44,7 +44,7 @@ public class NoopOutputPlugin extends OutputPlugin {
         @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("filter") Optional<Filter> filter
     ) {
-        super(filter, Batching.from(flushInterval, batching, Optional.of(DEFAULT_FLUSH_INTERVAL)));
+        super(filter, Batching.from(flushInterval.orElse(DEFAULT_FLUSH_INTERVAL), batching));
     }
 
     @Override

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -41,7 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.Getter;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +51,11 @@ public class CoreOutputManager implements OutputManager {
     private static final Logger log = LoggerFactory.getLogger(CoreOutputManager.class);
 
     @Inject
-    @Getter
     private List<PluginSink> sinks;
+
+    public List<PluginSink> getSinks() {
+        return this.sinks;
+    }
 
     @Inject
     private AsyncFramework async;
@@ -105,6 +108,15 @@ public class CoreOutputManager implements OutputManager {
 
     @Inject
     private Filter filter;
+
+    @Inject
+    @Named("rateLimit")
+    @Nullable
+    private Integer rateLimit;
+
+    public Integer getRateLimit() {
+        return rateLimit;
+    }
 
     @Override
     public void init() {

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 
 public class OutputManagerModule {
     private static final List<OutputPlugin> DEFAULT_PLUGINS = Lists.newArrayList();
@@ -54,13 +55,17 @@ public class OutputManagerModule {
 
     private final List<OutputPlugin> plugins;
     private final Filter filter;
+    @Nullable private final Integer rateLimit;
 
     @JsonCreator
     public OutputManagerModule(
-        @JsonProperty("plugins") List<OutputPlugin> plugins, @JsonProperty("filter") Filter filter
+        @JsonProperty("plugins") List<OutputPlugin> plugins,
+        @JsonProperty("filter") Filter filter,
+        @JsonProperty("ratelimit") @Nullable Integer rateLimit
     ) {
         this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
         this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
+        this.rateLimit = rateLimit;
     }
 
     public Module module() {
@@ -147,6 +152,13 @@ public class OutputManagerModule {
                 return filter;
             }
 
+            @Provides
+            @Singleton
+            @Named("rateLimit")
+            public Integer rateLimit() {
+                return rateLimit;
+            }
+
             @Override
             protected void configure() {
                 bind(OutputManager.class).to(CoreOutputManager.class).in(Scopes.SINGLETON);
@@ -222,6 +234,6 @@ public class OutputManagerModule {
     }
 
     public static Supplier<OutputManagerModule> supplyDefault() {
-        return () -> new OutputManagerModule(null, null);
+        return () -> new OutputManagerModule(null, null, null);
     }
 }

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -155,6 +155,7 @@ public class OutputManagerModule {
             @Provides
             @Singleton
             @Named("rateLimit")
+            @Nullable
             public Integer rateLimit() {
                 return rateLimit;
             }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpOutputPlugin.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpOutputPlugin.java
@@ -55,7 +55,7 @@ public class HttpOutputPlugin extends OutputPlugin {
         @JsonProperty("filter") Optional<Filter> filter
 
     ) {
-        super(filter, Batching.from(flushInterval, batching, Optional.of(DEFAULT_FLUSH_INTERVAL)));
+        super(filter, Batching.from(flushInterval.orElse(DEFAULT_FLUSH_INTERVAL), batching));
         this.discovery = Optional.ofNullable(discovery).orElseGet(HttpDiscovery::supplyDefault);
     }
 

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaOutputPlugin.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaOutputPlugin.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nullable;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.ProducerConfig;
 
@@ -54,7 +55,7 @@ public class KafkaOutputPlugin extends OutputPlugin {
     @JsonCreator
     public KafkaOutputPlugin(
         @JsonProperty("producer") Map<String, String> properties,
-        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("flushInterval") @Nullable Long flushInterval,
         @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("router") KafkaRouter router,
         @JsonProperty("partitioner") KafkaPartitioner partitioner,

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubOutputPlugin.java
@@ -50,6 +50,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.threeten.bp.Duration;
 
 public class PubsubOutputPlugin extends OutputPlugin {
@@ -71,7 +72,7 @@ public class PubsubOutputPlugin extends OutputPlugin {
   @JsonCreator
   public PubsubOutputPlugin(
     @JsonProperty("filter") Optional<Filter> filter,
-    @JsonProperty("flushInterval") Optional<Long> flushInterval,
+    @JsonProperty("flushInterval") @Nullable Long flushInterval,
     @JsonProperty("batching") Optional<Batching> batching,
     @JsonProperty("serializer") Serializer serializer,
 

--- a/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
+++ b/modules/riemann/src/main/java/com/spotify/ffwd/riemann/RiemannOutputPlugin.java
@@ -38,6 +38,7 @@ import com.spotify.ffwd.protocol.ProtocolPluginSink;
 import com.spotify.ffwd.protocol.ProtocolType;
 import com.spotify.ffwd.protocol.RetryPolicy;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class RiemannOutputPlugin extends OutputPlugin {
     private static final ProtocolType DEFAULT_PROTOCOL = ProtocolType.TCP;
@@ -49,7 +50,7 @@ public class RiemannOutputPlugin extends OutputPlugin {
 
     @JsonCreator
     public RiemannOutputPlugin(
-        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("flushInterval") @Nullable Long flushInterval,
         @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("protocol") ProtocolFactory protocol,
         @JsonProperty("retry") RetryPolicy retry, @JsonProperty("filter") Optional<Filter> filter

--- a/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxOutputPlugin.java
+++ b/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxOutputPlugin.java
@@ -66,7 +66,7 @@ public class SignalFxOutputPlugin extends OutputPlugin {
         @JsonProperty("batching") Optional<Batching> batching,
         @JsonProperty("soTimeout") Integer soTimeout,
         @JsonProperty("filter") Optional<Filter> filter) {
-        super(filter, Batching.from(flushInterval, batching, Optional.of(DEFAULT_FLUSH_INTERVAL)));
+        super(filter, Batching.from(flushInterval.orElse(DEFAULT_FLUSH_INTERVAL), batching));
         this.sourceName = Optional.ofNullable(sourceName).orElse(DEFAULT_SOURCE_NAME);
         this.authToken = Optional
             .ofNullable(authToken)

--- a/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
+++ b/modules/template/src/main/java/com/spotify/ffwd/template/TemplateOutputPlugin.java
@@ -36,6 +36,7 @@ import com.spotify.ffwd.protocol.ProtocolPluginSink;
 import com.spotify.ffwd.protocol.ProtocolType;
 import com.spotify.ffwd.protocol.RetryPolicy;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +52,7 @@ public class TemplateOutputPlugin extends OutputPlugin {
         @JsonProperty("protocol") final ProtocolFactory protocol,
         @JsonProperty("retry") final RetryPolicy retry,
         @JsonProperty("filter") Optional<Filter> filter,
-        @JsonProperty("flushInterval") Optional<Long> flushInterval,
+        @JsonProperty("flushInterval") @Nullable Long flushInterval,
         @JsonProperty("batching") Optional<Batching> batching
     ) {
         super(filter, Batching.from(flushInterval, batching));


### PR DESCRIPTION
By default rate limiting is disabled. It can be configured in the yaml config as 
```yaml
output:
  rateLimit: x
```
or with the environment variable `FFWD_OUTPUT_RATELIMIT`. The value is number of metrics per second to allow. The limiter is non-blocking and metrics that exceed the limit will be dropped.

While exploring the output code I simplified some of the batching deserialization logic. Its a fairly small change, but I'm happy to break that out into a separate PR since its not really related.

Closes #132 
