### PR TITLE
Replace Guava RateLimiter with a bursty token bucket.

### DIFF
--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -93,7 +93,7 @@ public class FfwdConfigurationTest {
         CoreOutputManager outputManager = getOutputManager(null);
 
         assertEquals(100, outputManager.getTtl());
-        assertEquals(Double.valueOf(1000), outputManager.getRateLimit());
+        assertEquals(Long.valueOf(1000), outputManager.getRateLimit());
     }
 
     @Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.isomorphism</groupId>
+      <artifactId>token-bucket</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -211,7 +211,7 @@ public class CoreOutputManager implements OutputManager {
         }
         try {
             return rateLimiter.tryConsume(permits);
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // Thrown if permits > max capacity or permits is not a positive number
             return false;
         }

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -22,7 +22,6 @@ package com.spotify.ffwd.output;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.spotify.ffwd.debug.DebugServer;
@@ -38,8 +37,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.isomorphism.util.TokenBucket;
+import org.isomorphism.util.TokenBuckets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +50,7 @@ public class CoreOutputManager implements OutputManager {
     private static final String HOST = "host";
     private static final Logger log = LoggerFactory.getLogger(CoreOutputManager.class);
 
-    private final RateLimiter rateLimiter;
+    private final TokenBucket rateLimiter;
 
     @Inject
     private List<PluginSink> sinks;
@@ -109,17 +111,23 @@ public class CoreOutputManager implements OutputManager {
     @Inject
     private Filter filter;
 
-    public final Double getRateLimit() {
+    public final Long getRateLimit() {
         if (rateLimiter == null) {
             return null;
         }
-        return rateLimiter.getRate();
+        return rateLimiter.getCapacity();
     }
 
     @Inject
     CoreOutputManager(@Named("rateLimit") @Nullable Integer rateLimit) {
         if (rateLimit != null && rateLimit > 0) {
-            rateLimiter = RateLimiter.create(rateLimit);
+            // Create a rate limiter with a configurable QPS, and
+            // tick every half second to reduce the delay between refills.
+            rateLimiter = TokenBuckets.builder()
+              .withCapacity(rateLimit)
+              .withInitialTokens(rateLimit)
+              .withFixedIntervalRefillStrategy(rateLimit / 2, 500, TimeUnit.MILLISECONDS)
+              .build();
         } else {
             rateLimiter = null;
         }
@@ -146,6 +154,7 @@ public class CoreOutputManager implements OutputManager {
         debug.inspectMetric(DEBUG_ID, filtered);
 
         if (!rateLimitAllowed(1)) {
+            log.debug("Dropping a metric due to rate limiting");
             statistics.reportMetricsDroppedByRateLimit(1);
             return;
         }
@@ -166,6 +175,7 @@ public class CoreOutputManager implements OutputManager {
         int batchSize = batch.getPoints().size();
 
         if (batchSize > 0 && !rateLimitAllowed(batchSize)) {
+            log.debug("Dropping {} metrics due to rate limiting", batchSize);
             statistics.reportMetricsDroppedByRateLimit(batchSize);
             return;
         }
@@ -199,7 +209,12 @@ public class CoreOutputManager implements OutputManager {
         if (rateLimiter == null) {
             return true;
         }
-        return rateLimiter.tryAcquire(permits);
+        try {
+            return rateLimiter.tryConsume(permits);
+        } catch(IllegalArgumentException e) {
+            // Thrown if permits > max capacity or permits is not a positive number
+            return false;
+        }
     }
 
     /**

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
@@ -218,15 +218,18 @@ public class OutputManagerTest {
 
     @Test
     public void testDroppingRateLimiting() {
-        rateLimit = 1;
+        rateLimit = 5;
         OutputManager outputManager = createOutputManager();
         ArgumentCaptor<Metric> captor = ArgumentCaptor.forClass(Metric.class);
 
-        outputManager.sendMetric(m1);
+        // Send a burst of metrics, all should be accepted
+        for (int i = 0; i < rateLimit; i++) {
+            outputManager.sendMetric(m1);
+        }
+        // Next metric is expected to be dropped
         outputManager.sendMetric(m1);
 
-        // The first metric should be accepted and the second dropped
-        verify(sink, times(1)).sendMetric(captor.capture());
+        verify(sink, times(rateLimit)).sendMetric(captor.capture());
     }
 
     private Metric sendAndCaptureMetric(Metric metric) {

--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.isomorphism</groupId>
+        <artifactId>token-bucket</artifactId>
+        <version>1.6</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guice.version}</version>


### PR DESCRIPTION
The Guava RateLimiter uses a smoothing function to evenly disperse its tokens. This is problematic for bursty metric ingestion, as is often the case if the service batches metrics before sending them.

The token bucket is much simpler. It allows tokens to be acquired without regard to timing, and then refills the tokens on a fixed interval tick. If a burst of traffic needs to use all available permits, the bucket will allow it and on the next tick (every 500ms as configured in this PR) more tokens will be added to the bucket.