### PR TITLE
Update maven license plugin.

### DIFF
--- a/core/src/main/java/com/spotify/ffwd/AgentConfig.kt
+++ b/core/src/main/java/com/spotify/ffwd/AgentConfig.kt
@@ -1,6 +1,9 @@
-/*
+/*-
+ * -\-\-
+ * FastForward Core
+ * --
  * Copyright (C) 2016 - 2019 Spotify AB
- *
+ * --
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * -/-/-
  */
 
 package com.spotify.ffwd

--- a/pom.xml
+++ b/pom.xml
@@ -485,8 +485,9 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>2.0.0</version>
         <configuration combine.self="append">
+          <trimHeaderLine>true</trimHeaderLine>
           <excludes>
             <exclude>**/protobuf250/**</exclude>
           </excludes>


### PR DESCRIPTION
Newer versions of the plugin allow for trimming whitespace on the header, and will allow both trimmed and untrimmed headers when checking if a file has the license applied.