### PR TITLE
[generated] Fix host entry in resource map in GeneratedPluginSource.

### DIFF
--- a/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
+++ b/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
@@ -94,11 +94,12 @@ public class GeneratedPluginSource implements PluginSource {
             final Date time = null;
             final String host = generateHost(i);
             final Set<String> riemannTags = ImmutableSet.of();
-            final Map<String, String> tags = ImmutableMap.of("what", "metric-" + i);
+            final Map<String, String> tags = ImmutableMap.of(
+                "what", "metric-" + i,
+                "host", host
+            );
             final Map<String, String> resource = ImmutableMap.of();
             final String proc = null;
-
-            tags.put("host", host);
 
             metrics.add(new Metric(key, value, time, riemannTags, tags, resource, proc));
         }


### PR DESCRIPTION
As far as I can tell, GeneratedPluginSource is currently broken. I'm not sure if I'm missing something obvious but here's a fix that got it working for me.