### PR TITLE
update google auth library

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>ffwd-agent</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>FastForward Agent</name>
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>ffwd-api</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward API</name>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>ffwd-core</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>FastForward Core</name>

--- a/modules/carbon/pom.xml
+++ b/modules/carbon/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-carbon</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward Carbon Module</name>
 

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-http</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward HTTP Module</name>
 

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-json</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward JSON Module</name>
 

--- a/modules/kafka/pom.xml
+++ b/modules/kafka/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-kafka</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward Kafka Module</name>
 

--- a/modules/protobuf/pom.xml
+++ b/modules/protobuf/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-protobuf</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward Protobuf Module</name>
 

--- a/modules/pubsub/pom.xml
+++ b/modules/pubsub/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>com.spotify.ffwd</groupId>
         <artifactId>ffwd-parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.5.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>ffwd-module-pubsub</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>FastForward Pubsub Module</name>
 

--- a/modules/riemann/pom.xml
+++ b/modules/riemann/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-riemann</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward Riemann Module</name>
 

--- a/modules/signalfx/pom.xml
+++ b/modules/signalfx/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>com.spotify.ffwd</groupId>
         <artifactId>ffwd-parent</artifactId>
-        <version>0.5.2-SNAPSHOT</version>
+        <version>0.5.3-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
     <artifactId>ffwd-module-signalfx</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>FastForward SignalFx Module</name>
 

--- a/modules/template/pom.xml
+++ b/modules/template/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>ffwd-module-template</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>FastForward MyPlugin Module</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.spotify.ffwd</groupId>
   <artifactId>ffwd-parent</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>FastForward Parent</name>
@@ -162,6 +162,31 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-credentials</artifactId>
+        <version>0.17.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>0.17.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>1.31.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>1.19.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.spotify.ffwd</groupId>
         <artifactId>ffwd-api</artifactId>
         <version>${project.version}</version>
@@ -183,7 +208,7 @@
       </dependency>
       <dependency>
         <groupId>com.spotify.ffwd</groupId>
-          <artifactId>ffwd-module-http</artifactId>
+        <artifactId>ffwd-module-http</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/protobuf250/pom.xml
+++ b/protobuf250/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>ffwd-protobuf250</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>FastForward Packaging of Protobuf 2.5</name>
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.spotify.ffwd</groupId>
     <artifactId>ffwd-parent</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
We are using this ffwd shim as a sidecar container for pods running in GKE to publish metrics.
When enabling [workload identity]() on GKE clusters, we noticed all the applications that depend on “google-auth-library-credentials” version < 0.16.2 fail to run with errors 

```
com.google.auth.oauth2.ComputeEngineCredentials runningOnComputeEngine
INFO: Failed to detect whether we are running on Google Compute Engine.
com.google.api.client.http.HttpResponseException: 403 Forbidden
GKE Metadata Server encountered an error: Missing required header "Metadata-Flavor": "Google"
```

Upgrading the google-auth-library-credentials  library used by ffwd shim to 
[>= v0.16.2](https://github.com/googleapis/google-auth-library-java/releases/tag/v0.16.2) that has the [fix](https://github.com/googleapis/google-auth-library-java/pull/283) to add metadata-flavor header to the requests to metadata server 
