### PR TITLE
Specify udp protocol when running with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ __Head over to https://spotify.github.io/ffwd/ for documentation.__
 ffwd can be started quickly with docker. This can be useful to run locally when troubleshooting metrics with your service.
 
 ```bash
-docker run -it -p 19091:19091 -p 19000:19000 -p 8080:8080 spotify/ffwd:latest
+docker run -it -p 19091:19091/udp -p 19000:19000 -p 8080:8080 spotify/ffwd:latest
 ```
 
 # Production Debugging


### PR DESCRIPTION
Otherwise apollo/java-ffwd-clients will not show up when running locally.