### PR TITLE
Cardinality detection and limiting implementation

### DIFF
--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -33,7 +33,7 @@ import eu.toolchain.async.FutureFinished;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class SemanticCoreStatistics implements CoreStatistics {
     private static final int HISTOGRAM_TTL_MINUTES = 2;
@@ -86,7 +86,7 @@ public class SemanticCoreStatistics implements CoreStatistics {
     @Override
     public OutputManagerStatistics newOutputManager() {
         final MetricId m = metric.tagged("component", "output-manager");
-        final AtomicInteger metricsCardinality = new AtomicInteger();
+        final AtomicLong metricsCardinality = new AtomicLong();
 
         return new OutputManagerStatistics() {
             private final Counter sentMetrics =
@@ -123,7 +123,7 @@ public class SemanticCoreStatistics implements CoreStatistics {
             }
 
             @Override
-            public void reportMetricsCardinality(int cardinality) {
+            public void reportMetricsCardinality(long cardinality) {
                 metricsCardinality.set(cardinality);
             }
         };

--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -21,6 +21,7 @@
 package com.spotify.ffwd.statistics;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
@@ -32,6 +33,7 @@ import eu.toolchain.async.FutureFinished;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SemanticCoreStatistics implements CoreStatistics {
     private static final int HISTOGRAM_TTL_MINUTES = 2;
@@ -84,28 +86,45 @@ public class SemanticCoreStatistics implements CoreStatistics {
     @Override
     public OutputManagerStatistics newOutputManager() {
         final MetricId m = metric.tagged("component", "output-manager");
+        final AtomicInteger metricsCardinality = new AtomicInteger();
 
         return new OutputManagerStatistics() {
-            private final Meter sentMetrics =
-              registry.meter(m.tagged("what", "sent-metrics", "unit", "metric"));
-            private final Meter metricsDroppedByFilter =
-              registry.meter(m.tagged("what", "metrics-dropped-by-filter", "unit", "metric"));
-            private final Meter metricsDroppedByRateLimit =
-              registry.meter(m.tagged("what", "metrics-dropped-by-ratelimit", "unit", "metric"));
+            private final Counter sentMetrics =
+              registry.counter(m.tagged("what", "sent-metrics", "unit", "metric"));
+            private final Counter metricsDroppedByFilter =
+              registry.counter(m.tagged("what", "metrics-dropped-by-filter", "unit", "metric"));
+            private final Counter metricsDroppedByRateLimit =
+              registry.counter(m.tagged("what", "metrics-dropped-by-ratelimit", "unit", "metric"));
+            private final Counter metricsDroppedByCardinalityLimit =
+              registry.counter(m.tagged("what", "metrics-dropped-by-cardlimit", "unit", "metric"));
+
+            private final Gauge metricsCardinalityMetric =
+              registry.register(m.tagged("what", "metrics-cardinality"),
+                  (Gauge<Long>) () -> (long) metricsCardinality.get());
 
             @Override
             public void reportSentMetrics(int sent) {
-                sentMetrics.mark(sent);
+                sentMetrics.inc(sent);
             }
 
             @Override
             public void reportMetricsDroppedByFilter(int dropped) {
-                metricsDroppedByFilter.mark(dropped);
+                metricsDroppedByFilter.inc(dropped);
             }
 
             @Override
             public void reportMetricsDroppedByRateLimit(int dropped) {
-                metricsDroppedByRateLimit.mark(dropped);
+                metricsDroppedByRateLimit.inc(dropped);
+            }
+
+            @Override
+            public void reportMetricsDroppedByCardinalityLimit(int dropped) {
+                metricsDroppedByCardinalityLimit.inc(dropped);
+            }
+
+            @Override
+            public void reportMetricsCardinality(int cardinality) {
+                metricsCardinality.set(cardinality);
             }
         };
     }

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -90,7 +90,7 @@ public class FfwdConfigurationTest {
         environmentVariables.set("FFWD_TTL", "100");
         environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
         environmentVariables.set("FFWD_OUTPUT_CARDINALITYLIMIT", "10000");
-        environmentVariables.set("FFWD_OUTPUT_HYPERLOGLOGSWAPPERIODMS", "3000000");
+        environmentVariables.set("FFWD_OUTPUT_CARDINALITYTTL", "3000000");
 
         CoreOutputManager outputManager = getOutputManager(null);
 

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -90,7 +90,7 @@ public class FfwdConfigurationTest {
         environmentVariables.set("FFWD_TTL", "100");
         environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
         environmentVariables.set("FFWD_OUTPUT_CARDINALITYLIMIT", "10000");
-        environmentVariables.set("FFWD_OUTPUT_HYPERLOGLOGSWAPPERIOD", "3000000");
+        environmentVariables.set("FFWD_OUTPUT_HYPERLOGLOGSWAPPERIODMS", "3000000");
 
         CoreOutputManager outputManager = getOutputManager(null);
 

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -89,11 +89,13 @@ public class FfwdConfigurationTest {
     public void testConfigFromEnvVars() {
         environmentVariables.set("FFWD_TTL", "100");
         environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
+        environmentVariables.set("FFWD_OUTPUT_CARDINALITYLIMIT", "10000");
 
         CoreOutputManager outputManager = getOutputManager(null);
 
         assertEquals(100, outputManager.getTtl());
         assertEquals(Long.valueOf(1000), outputManager.getRateLimit());
+        assertEquals(Long.valueOf(10000), outputManager.getCardinalityLimit());
     }
 
     @Test
@@ -112,6 +114,7 @@ public class FfwdConfigurationTest {
 
         assertEquals(100, outputManager.getTtl());
         assertEquals("jimjam", outputManager.getHost());
+        assertEquals(Long.valueOf(10000), outputManager.getCardinalityLimit());
     }
 
     private CoreOutputManager getOutputManager(final Path configPath) {

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -90,12 +90,14 @@ public class FfwdConfigurationTest {
         environmentVariables.set("FFWD_TTL", "100");
         environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
         environmentVariables.set("FFWD_OUTPUT_CARDINALITYLIMIT", "10000");
+        environmentVariables.set("FFWD_OUTPUT_HYPERLOGLOGSWAPPERIOD", "3000000");
 
         CoreOutputManager outputManager = getOutputManager(null);
 
         assertEquals(100, outputManager.getTtl());
         assertEquals(Long.valueOf(1000), outputManager.getRateLimit());
         assertEquals(Long.valueOf(10000), outputManager.getCardinalityLimit());
+        assertEquals(Long.valueOf(3000000), outputManager.getHLLPRefreshPeriodLimit());
     }
 
     @Test
@@ -115,6 +117,7 @@ public class FfwdConfigurationTest {
         assertEquals(100, outputManager.getTtl());
         assertEquals("jimjam", outputManager.getHost());
         assertEquals(Long.valueOf(10000), outputManager.getCardinalityLimit());
+        assertEquals(Long.valueOf(555555), outputManager.getHLLPRefreshPeriodLimit());
     }
 
     private CoreOutputManager getOutputManager(final Path configPath) {

--- a/agent/src/test/resources/basic-settings.yaml
+++ b/agent/src/test/resources/basic-settings.yaml
@@ -1,2 +1,4 @@
 ttl: 50
 host: jimjam
+output:
+  cardinalitylimit: 10000

--- a/agent/src/test/resources/basic-settings.yaml
+++ b/agent/src/test/resources/basic-settings.yaml
@@ -2,3 +2,4 @@ ttl: 50
 host: jimjam
 output:
   cardinalitylimit: 10000
+  hyperloglogswapperiod: 555555

--- a/agent/src/test/resources/basic-settings.yaml
+++ b/agent/src/test/resources/basic-settings.yaml
@@ -2,4 +2,4 @@ ttl: 50
 host: jimjam
 output:
   cardinalitylimit: 10000
-  hyperloglogswapperiodms: 555555
+  cardinalityttl: 555555

--- a/agent/src/test/resources/basic-settings.yaml
+++ b/agent/src/test/resources/basic-settings.yaml
@@ -2,4 +2,4 @@ ttl: 50
 host: jimjam
 output:
   cardinalitylimit: 10000
-  hyperloglogswapperiod: 555555
+  hyperloglogswapperiodms: 555555

--- a/api/src/main/java/com/spotify/ffwd/model/Batch.java
+++ b/api/src/main/java/com/spotify/ffwd/model/Batch.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(of = {"commonTags", "commonResource"})
 public class Batch {
     private final Map<String, String> commonTags;
     private final Map<String, String> commonResource;

--- a/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
@@ -64,6 +64,6 @@ public interface OutputManagerStatistics {
      *
      * @param cardinality The cardinality number of metrics sent.
      */
-    default void reportMetricsCardinality(int cardinality) {
+    default void reportMetricsCardinality(long cardinality) {
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
+++ b/api/src/main/java/com/spotify/ffwd/statistics/OutputManagerStatistics.java
@@ -48,4 +48,22 @@ public interface OutputManagerStatistics {
      */
     default void reportMetricsDroppedByRateLimit(int dropped) {
     }
+
+    /**
+     * Reported that the given number of metrics were dropped due to a cardinality limit.
+     * <p>
+     * Dropped metrics are <em>not</em> sent to output plugins.
+     *
+     * @param dropped The number of dropped metrics.
+     */
+    default void reportMetricsDroppedByCardinalityLimit(int dropped) {
+    }
+
+    /**
+     * Report current cardinality of metrics sent to output plugins.
+     *
+     * @param cardinality The cardinality number of metrics sent.
+     */
+    default void reportMetricsCardinality(int cardinality) {
+    }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,5 +116,23 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,17 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>9</source>
-          <target>9</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 
   <parent>
     <groupId>com.spotify.ffwd</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,5 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>9</source>
+          <target>9</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <parent>
     <groupId>com.spotify.ffwd</groupId>
@@ -86,6 +98,11 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.clearspring.analytics</groupId>
+      <artifactId>stream</artifactId>
     </dependency>
 
     <!-- testing -->

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -56,16 +56,19 @@ public class OutputManagerModule {
     private final List<OutputPlugin> plugins;
     private final Filter filter;
     @Nullable private final Integer rateLimit;
+    @Nullable private final Long cardinalityLimit;
 
     @JsonCreator
     public OutputManagerModule(
         @JsonProperty("plugins") List<OutputPlugin> plugins,
         @JsonProperty("filter") Filter filter,
-        @JsonProperty("ratelimit") @Nullable Integer rateLimit
+        @JsonProperty("ratelimit") @Nullable Integer rateLimit,
+        @JsonProperty("cardinalitylimit") @Nullable Long cardinalityLimit
     ) {
         this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
         this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
         this.rateLimit = rateLimit;
+        this.cardinalityLimit = cardinalityLimit;
     }
 
     public Module module() {
@@ -160,6 +163,14 @@ public class OutputManagerModule {
                 return rateLimit;
             }
 
+            @Provides
+            @Singleton
+            @Named("cardinalityLimit")
+            @Nullable
+            public Long cardinalityLimit() {
+                return cardinalityLimit;
+            }
+
             @Override
             protected void configure() {
                 bind(OutputManager.class).to(CoreOutputManager.class).in(Scopes.SINGLETON);
@@ -235,6 +246,6 @@ public class OutputManagerModule {
     }
 
     public static Supplier<OutputManagerModule> supplyDefault() {
-        return () -> new OutputManagerModule(null, null, null);
+        return () -> new OutputManagerModule(null, null, null, null);
     }
 }

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -65,7 +65,7 @@ public class OutputManagerModule {
         @JsonProperty("filter") Filter filter,
         @JsonProperty("ratelimit") @Nullable Integer rateLimit,
         @JsonProperty("cardinalitylimit") @Nullable Long cardinalityLimit,
-        @JsonProperty("hyperloglogswapperiodms") @Nullable Long hyperLogLogPlusSwapPeriodMS
+        @JsonProperty("cardinalityttl") @Nullable Long hyperLogLogPlusSwapPeriodMS
     ) {
         this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
         this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -57,7 +57,7 @@ public class OutputManagerModule {
     private final Filter filter;
     @Nullable private final Integer rateLimit;
     @Nullable private final Long cardinalityLimit;
-    @Nullable private final Long hyperLogLogPlusSwapPeriod;
+    @Nullable private final Long hyperLogLogPlusSwapPeriodMS;
 
     @JsonCreator
     public OutputManagerModule(
@@ -65,13 +65,13 @@ public class OutputManagerModule {
         @JsonProperty("filter") Filter filter,
         @JsonProperty("ratelimit") @Nullable Integer rateLimit,
         @JsonProperty("cardinalitylimit") @Nullable Long cardinalityLimit,
-        @JsonProperty("hyperloglogswapperiod") @Nullable Long hyperLogLogPlusSwapPeriod
+        @JsonProperty("hyperloglogswapperiodms") @Nullable Long hyperLogLogPlusSwapPeriodMS
     ) {
         this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
         this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
         this.rateLimit = rateLimit;
         this.cardinalityLimit = cardinalityLimit;
-        this.hyperLogLogPlusSwapPeriod = hyperLogLogPlusSwapPeriod;
+        this.hyperLogLogPlusSwapPeriodMS = hyperLogLogPlusSwapPeriodMS;
     }
 
     public Module module() {
@@ -176,10 +176,10 @@ public class OutputManagerModule {
 
             @Provides
             @Singleton
-            @Named("hyperLogLogPlusSwapPeriod")
+            @Named("hyperLogLogPlusSwapPeriodMS")
             @Nullable
-            public Long hyperLogLogPlusSwapPeriod() {
-                return hyperLogLogPlusSwapPeriod;
+            public Long hyperLogLogPlusSwapPeriodMS() {
+                return hyperLogLogPlusSwapPeriodMS;
             }
 
             @Override

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -57,18 +57,21 @@ public class OutputManagerModule {
     private final Filter filter;
     @Nullable private final Integer rateLimit;
     @Nullable private final Long cardinalityLimit;
+    @Nullable private final Long hyperLogLogPlusSwapPeriod;
 
     @JsonCreator
     public OutputManagerModule(
         @JsonProperty("plugins") List<OutputPlugin> plugins,
         @JsonProperty("filter") Filter filter,
         @JsonProperty("ratelimit") @Nullable Integer rateLimit,
-        @JsonProperty("cardinalitylimit") @Nullable Long cardinalityLimit
+        @JsonProperty("cardinalitylimit") @Nullable Long cardinalityLimit,
+        @JsonProperty("hyperloglogswapperiod") @Nullable Long hyperLogLogPlusSwapPeriod
     ) {
         this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
         this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
         this.rateLimit = rateLimit;
         this.cardinalityLimit = cardinalityLimit;
+        this.hyperLogLogPlusSwapPeriod = hyperLogLogPlusSwapPeriod;
     }
 
     public Module module() {
@@ -171,6 +174,14 @@ public class OutputManagerModule {
                 return cardinalityLimit;
             }
 
+            @Provides
+            @Singleton
+            @Named("hyperLogLogPlusSwapPeriod")
+            @Nullable
+            public Long hyperLogLogPlusSwapPeriod() {
+                return hyperLogLogPlusSwapPeriod;
+            }
+
             @Override
             protected void configure() {
                 bind(OutputManager.class).to(CoreOutputManager.class).in(Scopes.SINGLETON);
@@ -246,6 +257,6 @@ public class OutputManagerModule {
     }
 
     public static Supplier<OutputManagerModule> supplyDefault() {
-        return () -> new OutputManagerModule(null, null, null, null);
+        return () -> new OutputManagerModule(null, null, null, null, null);
     }
 }

--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
     <Logger name="kafka.consumer" level="INFO" additivity="false">
       <AppenderRef ref="primary" />
     </Logger>
-    <Logger name="com.spotify.ffwd" level="WARN" additivity="false">
+    <Logger name="com.spotify.ffwd" level="INFO" additivity="false">
       <AppenderRef ref="primary" />
     </Logger>
     <Logger name="io.netty" level="WARN" additivity="false">

--- a/core/src/main/resources/log4j2.xml
+++ b/core/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
     <Logger name="kafka.consumer" level="INFO" additivity="false">
       <AppenderRef ref="primary" />
     </Logger>
-    <Logger name="com.spotify.ffwd" level="INFO" additivity="false">
+    <Logger name="com.spotify.ffwd" level="WARN" additivity="false">
       <AppenderRef ref="primary" />
     </Logger>
     <Logger name="io.netty" level="WARN" additivity="false">

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
@@ -57,6 +57,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -79,6 +80,7 @@ public class OutputManagerTest {
     private String host = HOST;
     private long ttl = 0L;
     private Integer rateLimit = null;
+    private Long cardinalityLimit = null;
 
     @Mock
     private DebugServer debugServer;
@@ -93,6 +95,7 @@ public class OutputManagerTest {
 
     @Before
     public void setup() {
+        MockitoAnnotations.initMocks(this);
         tags.put("role", "abc");
         tagsToResource.put("foo", "bar");
         resource.put("gke_pod", "123");
@@ -134,6 +137,7 @@ public class OutputManagerTest {
                 bind(OutputManagerStatistics.class).toInstance(statistics);
                 bind(Filter.class).toInstance(filter);
                 bind(OutputManager.class).to(CoreOutputManager.class);
+                bind(Long.class).annotatedWith(Names.named("cardinalityLimit")).toProvider(Providers.of(cardinalityLimit));
             }
         });
 
@@ -252,6 +256,42 @@ public class OutputManagerTest {
         final Batch.Point expected = new Batch.Point(null, ImmutableMap.of("role","abc"),
             ImmutableMap.of("bar","fooval"), m1.getValue(), m1.getTime().getTime());
         assertEquals(expected, sendAndCaptureBatch(batch).getPoints().get(0));
+    }
+
+    @Test
+    public void testBatchCardinalityNotDropping() {
+        cardinalityLimit = 5L;
+        Map<String, String> m2Tags = new HashMap<>();
+        m2Tags.put("role", "abc");
+        m2Tags.put("foo", "fooval");
+
+        final Batch.Point point = new Batch.Point(null, m2Tags, m1.getResource(), m1.getValue(), m1.getTime().getTime());
+        final Batch batch = new Batch(Maps.newHashMap(), Maps.newHashMap(), Collections.singletonList(point));
+
+        final Batch.Point expected = new Batch.Point(null, ImmutableMap.of("role","abc"),
+            ImmutableMap.of("bar","fooval"), m1.getValue(), m1.getTime().getTime());
+        assertEquals(expected, sendAndCaptureBatch(batch).getPoints().get(0));
+    }
+
+    @Test
+    public void testBatchCardinalityDropping() {
+        cardinalityLimit = 19L;
+        int sendNum = 20;
+        OutputManager outputManager = createOutputManager();
+        ArgumentCaptor<Metric> captor = ArgumentCaptor.forClass(Metric.class);
+
+        // Send a burst of metrics, all should be accepted
+        for (int i = 0; i < sendNum; i++) {
+            outputManager.sendMetric(new Metric("main-key"+i, 42.0, new Date(), ImmutableSet.of(), Map.of("key"+i,"value"+i), ImmutableMap.of(), null));
+        }
+
+        verify(sink, times(sendNum-1)).sendMetric(captor.capture());
+
+        // Next metric shouldn't be dropped
+        Metric mKey = new Metric("ffwd-java", 42.0, new Date(), ImmutableSet.of(), ImmutableMap.of(), ImmutableMap.of(), null);
+        outputManager.sendMetric(mKey);
+
+        verify(sink, times(sendNum)).sendMetric(captor.capture());
     }
 
     private Metric sendAndCaptureMetric(Metric metric) {

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
@@ -81,7 +81,7 @@ public class OutputManagerTest {
     private long ttl = 0L;
     private Integer rateLimit = null;
     private Long cardinalityLimit = null;
-    private Long hyperLogLogPlusSwapPeriod = null;
+    private Long hyperLogLogPlusSwapPeriodMS = null;
 
     @Mock
     private DebugServer debugServer;
@@ -139,7 +139,8 @@ public class OutputManagerTest {
                 bind(Filter.class).toInstance(filter);
                 bind(OutputManager.class).to(CoreOutputManager.class);
                 bind(Long.class).annotatedWith(Names.named("cardinalityLimit")).toProvider(Providers.of(cardinalityLimit));
-                bind(Long.class).annotatedWith(Names.named("hyperLogLogPlusSwapPeriod")).toProvider(Providers.of(hyperLogLogPlusSwapPeriod));
+                bind(Long.class).annotatedWith(Names.named("hyperLogLogPlusSwapPeriodMS")).toProvider(Providers.of(
+                    hyperLogLogPlusSwapPeriodMS));
             }
         });
 
@@ -299,7 +300,7 @@ public class OutputManagerTest {
     @Test
     public void testBatchCardinalityDroppingWithSwap() {
         cardinalityLimit = 20L;
-        hyperLogLogPlusSwapPeriod = 2000L;
+        hyperLogLogPlusSwapPeriodMS = 2000L;
         int sendNum = 20;
         CoreOutputManager outputManager = (CoreOutputManager) createOutputManager();
         ArgumentCaptor<Metric> captor = ArgumentCaptor.forClass(Metric.class);

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,9 @@
     <kotlin.version>1.3.31</kotlin.version>
     <spotify-metrics.version>1.0.2</spotify-metrics.version>
     <findbugs.version>3.0.4</findbugs.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <profiles>
@@ -452,8 +455,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <compilerArgs>
             <compilerArg>-Xlint:all</compilerArg>
           </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,12 @@
         <version>0.0.3</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.clearspring.analytics</groupId>
+        <artifactId>stream</artifactId>
+        <version>2.9.8</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION
- Add cardinality limit based on [HyperLogLogPlus](https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLogPlus.java)
- Add cardinality metric for observability
- For **batch** using "commonTags" and "commonResource" for hashing - feel this should be reviewed as we go to include all tags and values in the batch
- For single **metric** using same tags as original metric ("key", "riemannTags", "tags")
- Cardinality will be reset by swapping HyperLogLogPlus after configurable time in case it was tripped

Closes: #181