### PR TITLE
Ignore small bursts of high freq metrics

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/util/HighFrequencyDetector.java
+++ b/api/src/main/java/com/spotify/ffwd/util/HighFrequencyDetector.java
@@ -43,6 +43,8 @@ import org.slf4j.Logger;
  */
 public class HighFrequencyDetector {
 
+  public static final int BURST_THRESHOLD = 5;
+
   /** Allow to drop high frequency metrics. */
   @Inject
   @Named("dropHighFrequencyMetric")
@@ -139,8 +141,13 @@ public class HighFrequencyDetector {
 
     int result = -1;
 
-    if (stats.getCount() > 5) {
-      // uses minimal time delta from all consecutive data points
+    /**
+     * In order to be marked as high frequency metric the number of points
+     * should be above the BURST_THRESHOLD.
+     * It ignores any small bursts of high frequency metrics.
+     */
+    if (stats.getCount() > BURST_THRESHOLD) {
+      // uses minimal delta time from all consecutive data points
       result = stats.getMin();
       log.info("stats: " + stats);
     }

--- a/docs/content/_docs/modules.html
+++ b/docs/content/_docs/modules.html
@@ -11,6 +11,6 @@ Any software program on the host can send measurements directly to Fast Forward 
 <div class="jumbotron">
   <div class="container">
     <p class="lead">Current dependency graph</p>
-    <center><img src="images/dependency-graph.png" /></center>
+    <left><img width="1500" height="170" src="images/dependency-graph.png" /></left>
   </div>
 </div>


### PR DESCRIPTION
This change will allow to ignore small bursts of high frequency metrics. 
Some of existing systems duplicate their metric production and that skews high frequency detector.

+ @ao2017