### PR TITLE
Noop to retrigger build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Build Status](https://circleci.com/gh/spotify/ffwd.svg?style=svg)](https://circleci.com/gh/spotify/ffwd)
 [![License](https://img.shields.io/github/license/spotify/ffwd.svg)](LICENSE)
 
-
 ffwd is a flexible metric forwarding agent. It is intended to run locally on the system and receive metrics through a wide set of protocols and then forward them to your TSDB.
 
 By running locally, it is easily available to receive pushed data from any application or service that is running on the same system.


### PR DESCRIPTION
https://github.com/spotify/ffwd/commit/39bc5f679e712c7ba367fd5abda410a560e8e7ef failed due to a (transient?) docker hub issue which serves up a 404 (https://hub.docker.com/login/?next=/redirect/%3Fresource_uri%3D/api/audit/v1/action/d032f78b-6401-48f7-9cbe-996a5d896898/)

@lmuhlha 