### PR TITLE
Add java-11-amazon-corretto-jdk package dep

### DIFF
--- a/agent/src/deb/bin/ffwd
+++ b/agent/src/deb/bin/ffwd
@@ -26,7 +26,7 @@ if [[ ! -f $JVMARGS ]]; then
 fi
 
 if [[ -z $JAVA ]]; then
-    for java in "/usr/lib/jvm/java-11-amazon-corretto/bin/java" "/usr/lib/jvm/oracle-java11-jdk-amd64/bin/java" "/usr/lib/jvm/java11-jdk/bin/java" "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"; do
+    for java in "/usr/lib/jvm/java-11-amazon-corretto-noalt/bin/java" "/usr/lib/jvm/oracle-java11-jdk-amd64/bin/java" "/usr/lib/jvm/java11-jdk/bin/java" "/usr/lib/jvm/java-11-openjdk-amd64/bin/java"; do
         if [[ -x $java ]]; then
             JAVA=$java
             break

--- a/agent/src/deb/control/control
+++ b/agent/src/deb/control/control
@@ -10,6 +10,6 @@ Build-Depends:
  maven (>= 3)
 Standards-Version: 3.9.1
 Architecture: all
-Depends: oracle-jvm-11 (>=11.0.2-1spotify1) | openjdk-11-jre-headless
+Depends: java-11-amazon-corretto-jdk-noalt (>=1:11.0.8.10-1spotify1) | oracle-jvm-11 (>=11.0.2-1spotify1) | openjdk-11-jre-headless
 Description: FastForward Java Agent
  FastForward is a metrics forwarding agent


### PR DESCRIPTION
@lmuhlha @malish8632 @sjoeboo @RochesterinNYC

https://github.com/spotify/ffwd/pull/200 only added support for running with Corretto if it was available. These changes allow to have Corretto, Oracle, or OpenJDK satisfy the Depends field.