### PR TITLE
Noop to retrigger build

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ To release, run:
 You will be prompted for the release version and the next development version.
 
 Add a Github release based on the tag that was created from the above command with notes on what changed.
+


### PR DESCRIPTION
0.6.5 was not published to docker hub on the latest release.