### PR TITLE
Replace System Rules with System Lambda

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -103,7 +103,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
+      <artifactId>system-lambda</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
+++ b/agent/src/test/java/com/spotify/ffwd/FfwdConfigurationTest.java
@@ -20,6 +20,7 @@
 
 package com.spotify.ffwd;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -34,17 +35,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FfwdConfigurationTest {
-
-    @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Test
     public void testConfAllPluginsEnabled() {
@@ -86,13 +82,12 @@ public class FfwdConfigurationTest {
     }
 
     @Test
-    public void testConfigFromEnvVars() {
-        environmentVariables.set("FFWD_TTL", "100");
-        environmentVariables.set("FFWD_OUTPUT_RATELIMIT", "1000");
-        environmentVariables.set("FFWD_OUTPUT_CARDINALITYLIMIT", "10000");
-        environmentVariables.set("FFWD_OUTPUT_CARDINALITYTTL", "3000000");
-
-        CoreOutputManager outputManager = getOutputManager(null);
+    public void testConfigFromEnvVars() throws Exception {
+        CoreOutputManager outputManager = withEnvironmentVariable("FFWD_TTL", "100")
+                .and("FFWD_OUTPUT_RATELIMIT", "1000")
+                .and("FFWD_OUTPUT_CARDINALITYLIMIT", "10000")
+                .and("FFWD_OUTPUT_CARDINALITYTTL", "3000000")
+                .execute(() -> getOutputManager(null));
 
         assertEquals(100, outputManager.getTtl());
         assertEquals(Long.valueOf(1000), outputManager.getRateLimit());
@@ -109,10 +104,10 @@ public class FfwdConfigurationTest {
     }
 
     @Test
-    public void testMergeOrder() {
-        environmentVariables.set("FFWD_TTL", "100");
+    public void testMergeOrder() throws Exception {
         Path configPath = resource("basic-settings.yaml");
-        CoreOutputManager outputManager = getOutputManager(configPath);
+        CoreOutputManager outputManager = withEnvironmentVariable("FFWD_TTL", "100")
+                .execute(() -> getOutputManager(configPath));
 
         assertEquals(100, outputManager.getTtl());
         assertEquals("jimjam", outputManager.getHost());

--- a/pom.xml
+++ b/pom.xml
@@ -409,8 +409,8 @@
       </dependency>
       <dependency>
         <groupId>com.github.stefanbirkner</groupId>
-        <artifactId>system-rules</artifactId>
-        <version>1.19.0</version>
+        <artifactId>system-lambda</artifactId>
+        <version>1.1.0</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
System Lambda is more specific. It only wraps the part of the code that
reads the environment variables.