### PR TITLE
Use different library for HyperLogLog algorithm

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -89,8 +89,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.clearspring.analytics</groupId>
-      <artifactId>stream</artifactId>
+      <groupId>net.agkn</groupId>
+      <artifactId>hll</artifactId>
     </dependency>
 
     <!-- testing -->

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -20,7 +20,7 @@
 
 package com.spotify.ffwd.output;
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import net.agkn.hll.HLL;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -48,6 +48,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+
+import net.agkn.hll.HLLType;
 import org.isomorphism.util.TokenBucket;
 import org.isomorphism.util.TokenBuckets;
 import org.slf4j.Logger;
@@ -59,7 +61,7 @@ public class CoreOutputManager implements OutputManager {
     private static final Logger log = LoggerFactory.getLogger(CoreOutputManager.class);
     private static final String[] KEYS_NEVER_TO_DROP = {"ffwd-java", "ffwd-java.ffwd-java"};
     private static final int HYPER_LOG_LOG_PLUS_PRECISION_NORMAL = 14;
-    private static final int HYPER_LOG_LOG_PLUS_PRECISION_SPARSE = 25;
+    private static final int HYPER_LOG_LOG_PLUS_PRECISION_SPARSE = 5;
 
     private final TokenBucket rateLimiter;
     private final Long cardinalityLimit;
@@ -123,7 +125,7 @@ public class CoreOutputManager implements OutputManager {
     @Inject
     private Filter filter;
 
-    private AtomicReference<HyperLogLogPlus> hyperLog;
+    private AtomicReference<HLL> hyperLog;
     private AtomicLong hyperLogSwapTS;
     private AtomicBoolean hyperLogSwapLock;
     private Long hyperLogLogPlusSwapPeriodMS;
@@ -161,8 +163,10 @@ public class CoreOutputManager implements OutputManager {
             rateLimiter = null;
         }
 
-        hyperLog = new AtomicReference<>(new HyperLogLogPlus(
-                HYPER_LOG_LOG_PLUS_PRECISION_NORMAL, HYPER_LOG_LOG_PLUS_PRECISION_SPARSE));
+        hyperLog = new AtomicReference<>(new HLL(
+                HYPER_LOG_LOG_PLUS_PRECISION_NORMAL,
+                HYPER_LOG_LOG_PLUS_PRECISION_SPARSE,
+                -1, false, HLLType.FULL));
         hyperLogSwapTS =  new AtomicLong(System.currentTimeMillis());
         hyperLogSwapLock = new AtomicBoolean(false);
         this.hyperLogLogPlusSwapPeriodMS =
@@ -199,7 +203,7 @@ public class CoreOutputManager implements OutputManager {
 
         debug.inspectMetric(DEBUG_ID, filtered);
 
-        hyperLog.get().offer(metric.hashCode());
+        hyperLog.get().addRaw(metric.hashCode());
         statistics.reportMetricsCardinality(hyperLog.get().cardinality());
 
         if (isDroppable(1, metric.getKey())) {
@@ -223,7 +227,7 @@ public class CoreOutputManager implements OutputManager {
 
         BatchMetricConverter
             .convertBatchesToMetrics(Collections.singletonList(batch))
-            .stream().forEach(metric -> hyperLog.get().offer(metric.hashCode()));
+            .stream().forEach(metric -> hyperLog.get().addRaw(metric.hashCode()));
 
         statistics.reportMetricsCardinality(hyperLog.get().cardinality());
 
@@ -278,8 +282,10 @@ public class CoreOutputManager implements OutputManager {
     private void swapHyperLogLogPlus() {
         if (System.currentTimeMillis() - hyperLogSwapTS.get() > hyperLogLogPlusSwapPeriodMS
             && hyperLogSwapLock.compareAndExchange(false, true)) {
-            hyperLog.set(new HyperLogLogPlus(
-                    HYPER_LOG_LOG_PLUS_PRECISION_NORMAL, HYPER_LOG_LOG_PLUS_PRECISION_SPARSE));
+            hyperLog.set(new HLL(
+                    HYPER_LOG_LOG_PLUS_PRECISION_NORMAL,
+                    HYPER_LOG_LOG_PLUS_PRECISION_SPARSE,
+                    -1, false, HLLType.FULL));
             hyperLogSwapTS.set(System.currentTimeMillis());
             hyperLogSwapLock.set(false);
         }

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -60,8 +60,8 @@ public class CoreOutputManager implements OutputManager {
     private static final String HOST = "host";
     private static final Logger log = LoggerFactory.getLogger(CoreOutputManager.class);
     private static final String[] KEYS_NEVER_TO_DROP = {"ffwd-java", "ffwd-java.ffwd-java"};
-    private static final int HYPER_LOG_LOG_PLUS_PRECISION_NORMAL = 14;
-    private static final int HYPER_LOG_LOG_PLUS_PRECISION_SPARSE = 5;
+    private static final int HYPER_LOG_LOG_LOG2M = 14;
+    private static final int HYPER_LOG_LOG_REG_WIDTH = 5;
 
     private final TokenBucket rateLimiter;
     private final Long cardinalityLimit;
@@ -164,8 +164,8 @@ public class CoreOutputManager implements OutputManager {
         }
 
         hyperLog = new AtomicReference<>(new HLL(
-                HYPER_LOG_LOG_PLUS_PRECISION_NORMAL,
-                HYPER_LOG_LOG_PLUS_PRECISION_SPARSE,
+                HYPER_LOG_LOG_LOG2M,
+                HYPER_LOG_LOG_REG_WIDTH,
                 -1, false, HLLType.FULL));
         hyperLogSwapTS =  new AtomicLong(System.currentTimeMillis());
         hyperLogSwapLock = new AtomicBoolean(false);
@@ -283,8 +283,8 @@ public class CoreOutputManager implements OutputManager {
         if (System.currentTimeMillis() - hyperLogSwapTS.get() > hyperLogLogPlusSwapPeriodMS
             && hyperLogSwapLock.compareAndExchange(false, true)) {
             hyperLog.set(new HLL(
-                    HYPER_LOG_LOG_PLUS_PRECISION_NORMAL,
-                    HYPER_LOG_LOG_PLUS_PRECISION_SPARSE,
+                    HYPER_LOG_LOG_LOG2M,
+                    HYPER_LOG_LOG_REG_WIDTH,
                     -1, false, HLLType.FULL));
             hyperLogSwapTS.set(System.currentTimeMillis());
             hyperLogSwapLock.set(false);

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
@@ -290,14 +290,14 @@ public class OutputManagerTest {
             outputManager.sendMetric(new Metric("main-key"+i, 42.0, new Date(), ImmutableSet.of(), Map.of("key"+i,"value"+i), ImmutableMap.of(), null));
         }
 
-        // dropped number 20 as it is above cardinality limit
-        verify(sink, times(sendNum-1)).sendMetric(captor.capture());
+        // sent 18 as cardinality limit is 19
+        verify(sink, times(sendNum-2)).sendMetric(captor.capture());
 
         // Next metric shouldn't be dropped as it uses special key
         Metric mKey = new Metric("ffwd-java", 42.0, new Date(), ImmutableSet.of(), ImmutableMap.of(), ImmutableMap.of(), null);
         outputManager.sendMetric(mKey);
 
-        verify(sink, times(sendNum)).sendMetric(captor.capture());
+        verify(sink, times(sendNum-1)).sendMetric(captor.capture());
     }
 
     @Test
@@ -325,7 +325,7 @@ public class OutputManagerTest {
             outputManager.sendMetric(new Metric("main-key"+i, 42.0, new Date(), ImmutableSet.of(), Map.of("key"+i,"value"+i), ImmutableMap.of(), null));
         }
 
-        verify(sink, times(39)).sendMetric(captor.capture());
+        verify(sink, times(38)).sendMetric(captor.capture());
     }
 
 
@@ -349,7 +349,7 @@ public class OutputManagerTest {
 
         outputManager.sendBatch(batch);
 
-        verify(sink, times(1)).sendBatch(captorBatch.capture());
+        verify(sink, times(0)).sendBatch(captorBatch.capture());
 
         // Next metric shouldn't be dropped as it uses special key
         Metric mKey = new Metric("ffwd-java", 42.0, new Date(), ImmutableSet.of(), ImmutableMap.of(), ImmutableMap.of(), null);
@@ -377,7 +377,7 @@ public class OutputManagerTest {
 
         final Batch batch = new Batch(Maps.newHashMap(), Maps.newHashMap(), points);
         outputManager.sendBatch(batch);
-        verify(sink, times(1)).sendBatch(captorBatch.capture());
+        verify(sink, times(0)).sendBatch(captorBatch.capture());
 
         // Next metric shouldn't be dropped as it uses special key
         Metric mKey = new Metric("ffwd-java", 42.0, new Date(), ImmutableSet.of(), ImmutableMap.of(), ImmutableMap.of(), null);

--- a/pom.xml
+++ b/pom.xml
@@ -363,9 +363,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.clearspring.analytics</groupId>
-        <artifactId>stream</artifactId>
-        <version>2.9.8</version>
+        <groupId>net.agkn</groupId>
+        <artifactId>hll</artifactId>
+        <version>1.6.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This PR introduces different [library](https://github.com/aggregateknowledge/java-hll) that implemented HyperLogLog algo.
Apparently [original library](https://github.com/addthis/stream-lib) was archived by the owner.

Some benchmarking was done by [external engineer](http://s-j.github.io/hyperloglog/).

The cause for this switch was occasional issues with our Metrics API where some instances wouldn't accept metrics. Investigation lead to this log discovery which indicate some issues in library implementation:

`java.lang.ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4
	at com.clearspring.analytics.stream.cardinality.HyperLogLogPlus.sortEncodedSet(HyperLogLogPlus.java:796)
	at com.clearspring.analytics.stream.cardinality.HyperLogLogPlus.mergeTempList(HyperLogLogPlus.java:764)
	at com.clearspring.analytics.stream.cardinality.HyperLogLogPlus.offerHashed(HyperLogLogPlus.java:321)
	at com.clearspring.analytics.stream.cardinality.HyperLogLogPlus.offer(HyperLogLogPlus.java:336)
	at com.spotify.ffwd.output.CoreOutputManager.lambda$sendBatch$1(CoreOutputManager.java:226)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at com.spotify.ffwd.output.CoreOutputManager.sendBatch(CoreOutputManager.java:226)
	at com.spotify.ffwd.input.CoreInputManager.receiveBatch(CoreInputManager.java:88)
	at com.spotify.ffwd.input.InputChannelInboundHandler.channelRead(InputChannelInboundHandler.java:47)
...`