### PR TITLE
Add tag refreshing functionality

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -106,6 +106,16 @@
       <artifactId>system-lambda</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/agent/src/test/resources/basic-settings-with-dynamic-tags-file.yaml
+++ b/agent/src/test/resources/basic-settings-with-dynamic-tags-file.yaml
@@ -1,0 +1,6 @@
+ttl: 50
+host: jimjam
+output:
+  dynamicTagsFile: src/test/resources/dynamic-tags-file.txt
+  cardinalitylimit: 10000
+  cardinalityttl: 555555

--- a/agent/src/test/resources/basic-settings-with-non-existent-dynamic-tags-file.yaml
+++ b/agent/src/test/resources/basic-settings-with-non-existent-dynamic-tags-file.yaml
@@ -1,0 +1,6 @@
+ttl: 50
+host: jimjam
+output:
+  dynamicTagsFile: does/not/exist
+  cardinalitylimit: 10000
+  cardinalityttl: 555555

--- a/agent/src/test/resources/dynamic-tags-file.txt
+++ b/agent/src/test/resources/dynamic-tags-file.txt
@@ -1,0 +1,3 @@
+not-specified="i-should-not-be-used"
+foo="qux"
+random="stuff"

--- a/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
+++ b/core/src/main/java/com/spotify/ffwd/output/OutputManagerModule.java
@@ -67,6 +67,7 @@ public class OutputManagerModule {
     private final int minFrequencyMillisAllowed;
     private final int minNumberOfTriggers;
     private final long highFrequencyDataRecycleMS;
+    @Nullable private final String dynamicTagsFile;
 
     @JsonCreator
     public OutputManagerModule(
@@ -78,7 +79,8 @@ public class OutputManagerModule {
         @JsonProperty("dropHighFrequencyMetric") @Nullable Boolean dropHighFrequencyMetric,
         @JsonProperty("minFrequencyMillisAllowed") @Nullable Integer minFrequencyMillisAllowed,
         @JsonProperty("minNumberOfTriggers") @Nullable Integer minNumberOfTriggers,
-        @JsonProperty("highFrequencyDataRecycleMS") @Nullable Long highFrequencyDataRecycleMS) {
+        @JsonProperty("highFrequencyDataRecycleMS") @Nullable Long highFrequencyDataRecycleMS,
+        @JsonProperty("dynamicTagsFile") @Nullable String dynamicTagsFile) {
       this.plugins = Optional.ofNullable(plugins).orElse(DEFAULT_PLUGINS);
       this.filter = Optional.ofNullable(filter).orElseGet(TrueFilter::new);
       this.rateLimit = rateLimit;
@@ -93,6 +95,7 @@ public class OutputManagerModule {
       this.highFrequencyDataRecycleMS =
           Optional.ofNullable(highFrequencyDataRecycleMS)
               .orElse(DEFAULT_HIGH_FREQUENCY_DATA_RECYCLE_MS);
+      this.dynamicTagsFile = dynamicTagsFile;
     }
 
     //CHECKSTYLE:OFF:MethodLength
@@ -238,6 +241,13 @@ public class OutputManagerModule {
                 return highFrequencyDataRecycleMS;
             }
 
+            @Provides
+            @Singleton
+            @Named("dynamicTagsFile")
+            public String dynamicTagsFile() {
+                return dynamicTagsFile;
+            }
+
             @Override
             protected void configure() {
                 bind(OutputManager.class).to(CoreOutputManager.class).in(Scopes.SINGLETON);
@@ -314,6 +324,7 @@ public class OutputManagerModule {
     }
 
     public static Supplier<OutputManagerModule> supplyDefault() {
-        return () -> new OutputManagerModule(null, null, null, null, null, null, null, null, null);
+        return () -> new OutputManagerModule(null, null, null, null, null, null, null, null, null,
+            null);
     }
 }

--- a/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
+++ b/core/src/test/java/com/spotify/ffwd/output/OutputManagerTest.java
@@ -139,6 +139,7 @@ public class OutputManagerTest {
                 bind(DebugServer.class).toInstance(debugServer);
                 bind(OutputManagerStatistics.class).toInstance(statistics);
                 bind(Filter.class).toInstance(filter);
+                bind(String.class).annotatedWith(Names.named("dynamicTagsFile")).toInstance("");
                 bind(OutputManager.class).to(CoreOutputManager.class);
                 bind(Long.class).annotatedWith(Names.named("cardinalityLimit")).toProvider(Providers.of(cardinalityLimit));
                 bind(Long.class).annotatedWith(Names.named("hyperLogLogPlusSwapPeriodMS")).toProvider(Providers.of(

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,18 @@
         <version>1.1.0</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.0.3</version>
+        <scope>test</scope>
+      </dependency>
 
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
PR is WIP. Please make any edits or suggestions.

`/Users/dxia/Downloads/work-notes/labels.yaml` looks like

```
cluster="test-cluster1"
rack="rack-22"
tugboat.spotify.com/stage="canary"
zone="us-est-coast"
```

Running this locally with the automatically enabled DebugPluginSink and the command

```
cat metric.json

{
  "points": [
    {
      "key": "test_key",
       "tags": {
         "what": "error-rate"
       },
       "resource": {},
       "value": 1234.0,
       "timestamp":11111
    }
  ]
}

cat metric.json | http POST http://localhost:8080/v1/batch 'Content-Type:application/json'
```

I get

```
19:32:35.447 [main] INFO  com.spotify.ffwd.AgentCore - Started!

19:33:57.723 [ffwd-scheduler-0] INFO  com.spotify.ffwd.debug.DebugPluginSink -
B#0: Batch(commonTags={cluster="test-cluster1", rack="rack-22",
tugboat.spotify.com/stage="canary", zone="us-est-coast", foo=bar, env=prod},
commonResource={}, points=[Batch.Point(key=test_key, tags={what=error-rate},
resource={}, value=1234.0, timestamp=11111)])
```

Then I change the contents of `labels.yaml` to have
`tugboat.spotify.com/stage="production"` and run the same command and get

```
19:34:40.382 [ffwd-scheduler-1] INFO  com.spotify.ffwd.debug.DebugPluginSink -
B#1: Batch(commonTags={cluster="test-cluster1", rack="rack-22",
tugboat.spotify.com/stage="production", zone="us-est-coast", foo=bar,
env=prod}, commonResource={}, points=[Batch.Point(key=test_key,
tags={what=error-rate}, resource={}, value=1234.0, timestamp=11111)])
```

This shows the tag is being refreshed.