### PR TITLE
don't setDistributionTypeValue if the metric is not a distribution type

### DIFF
--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
@@ -83,6 +83,7 @@ public class Spotify100ProtoSerializer implements Serializer {
         Spotify100.Value.Builder valueBuilder = Spotify100.Value.newBuilder();
 
         final com.spotify.ffwd.model.v2.Value value = metric.getValue();
+        Spotify100.Metric.Builder builder = Spotify100.Metric.newBuilder();
 
         if (value instanceof Value.DoubleValue) {
             Value.DoubleValue doubleValue = (Value.DoubleValue) value;
@@ -90,14 +91,13 @@ public class Spotify100ProtoSerializer implements Serializer {
         } else if (value instanceof Value.DistributionValue) {
             Value.DistributionValue distValue = (Value.DistributionValue) value;
             valueBuilder.setDistributionValue(distValue.getValue());
+            builder.setDistributionTypeValue(valueBuilder.build());
         } else {
             throw new UnknownFormatConversionException("Unknown value type [ " + value + " ]");
         }
 
 
-        Spotify100.Metric.Builder builder = Spotify100.Metric.newBuilder();
         builder.setKey(metric.getKey())
-            .setDistributionTypeValue(valueBuilder.build())
             .setTime(metric.getTime())
             .putAllTags(metric.getTags())
             .putAllResource(metric.getResource())

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -88,6 +88,7 @@ public class Spotify100ProtoSerializer implements Serializer {
         if (value instanceof Value.DoubleValue) {
             Value.DoubleValue doubleValue = (Value.DoubleValue) value;
             valueBuilder.setDoubleValue(doubleValue.getValue());
+            builder.setValue(valueBuilder.build().getDoubleValue());
         } else if (value instanceof Value.DistributionValue) {
             Value.DistributionValue distValue = (Value.DistributionValue) value;
             valueBuilder.setDistributionValue(distValue.getValue());

--- a/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
+++ b/core/src/test/java/com/spotify/ffwd/serializer/TestSpotify100ProtoSerializer.java
@@ -138,7 +138,7 @@ public class TestSpotify100ProtoSerializer {
      Spotify100.Batch spotify100BatchOut = deserialize(bytes);
 
      assertThat( value.getValue(), is(spotify100BatchOut.getMetricList()
-          .get(0).getDistributionTypeValue().getDoubleValue()));
+          .get(0).getValue()));
 
      assertThat( key, is(spotify100BatchOut.getMetricList()
             .get(0).getKey()));


### PR DESCRIPTION
The current way non-distribution metrics are being built conflicts with [this condition](https://github.com/spotify/heroic/blob/de3489066ce029137885014410aafd529c85ab2a/heroic-core/src/main/java/com/spotify/heroic/consumer/schemas/Spotify100Proto.java#L106) in the consumer. This PR makes sure to only set the metric [distribution_type_value](https://github.com/spotify/ffwd/blob/master/core/src/main/proto/spotify_100.proto#L25) if the metric is a distribution.