### PR TITLE
fix a few compiler/Maven warnings

### DIFF
--- a/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
+++ b/agent/src/main/java/com/spotify/ffwd/statistics/SemanticCoreStatistics.java
@@ -54,7 +54,7 @@ public class SemanticCoreStatistics implements CoreStatistics {
 
             @Override
             public boolean isInstance(final Metric metric) {
-                return Histogram.class.isInstance(metric);
+                return metric instanceof Histogram;
             }
         };
 
@@ -99,9 +99,9 @@ public class SemanticCoreStatistics implements CoreStatistics {
             private final Counter metricsDroppedByCardinalityLimit =
               registry.counter(m.tagged("what", "metrics-dropped-by-cardlimit", "unit", "metric"));
 
-            private final Gauge metricsCardinalityMetric =
+            private final Gauge<Long> metricsCardinalityMetric =
               registry.register(m.tagged("what", "metrics-cardinality"),
-                  (Gauge<Long>) () -> (long) metricsCardinality.get());
+                  (Gauge<Long>) metricsCardinality::get);
 
             @Override
             public void reportSentMetrics(int sent) {

--- a/modules/protobuf/pom.xml
+++ b/modules/protobuf/pom.xml
@@ -26,32 +26,21 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.spotify.ffwd</groupId>
       <artifactId>ffwd-client</artifactId>
       <version>0.2.4</version>
     </dependency>
 
-  <!-- testing -->
-  <dependency>
-    <groupId>junit</groupId>
-    <artifactId>junit</artifactId>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.mockito</groupId>
-    <artifactId>mockito-core</artifactId>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.mockito</groupId>
-    <artifactId>mockito-core</artifactId>
-    <scope>test</scope>
-  </dependency>
-
+    <!-- testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
I was investigating something unrelated to this, and noticed a few small warnings that seemed easy to fix:

- modules/protobuf: remove duplicate dependencies in pom.xml
- SemanticCoreStatistics: fix two compiler warnings
