### PR TITLE
Refactor Batch.Point to Metric

### DIFF
--- a/api/src/main/java/com/spotify/ffwd/model/v2/Batch.java
+++ b/api/src/main/java/com/spotify/ffwd/model/v2/Batch.java
@@ -38,45 +38,21 @@ import lombok.EqualsAndHashCode;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @EqualsAndHashCode(of = {"commonTags", "commonResource"})
 public class Batch {
+
     private final Map<String, String> commonTags;
     private final Map<String, String> commonResource;
-    private final List<Point> points;
+    private final List<Metric> points;
 
     /**
      * JSON creator.
      */
     @JsonCreator
     public static Batch create(
-        @JsonProperty("commonTags")
-        final Optional<Map<String, String>> commonTags,
+        @JsonProperty("commonTags") final Optional<Map<String, String>> commonTags,
         @JsonProperty("commonResource") final Optional<Map<String, String>> commonResource,
-        @JsonProperty("points") final List<Point> points
+        @JsonProperty("points") final List<Metric> points
     ) {
         return new Batch(commonTags.orElseGet(ImmutableMap::of),
             commonResource.orElseGet(ImmutableMap::of), points);
-    }
-
-    @Data
-    public static class Point {
-        private final String key;
-        private final Map<String, String> tags;
-        private final Map<String, String> resource;
-        private final Value value;
-        private final long timestamp;
-
-        /**
-         * JSON creator.
-         */
-        @JsonCreator
-        public static  Point create(
-            @JsonProperty("key") final String key,
-            @JsonProperty("tags") final Optional<Map<String, String>> tags,
-            @JsonProperty("resource") final Optional<Map<String, String>> resource,
-            @JsonProperty("value") final Value value,
-            @JsonProperty("timestamp") final long timestamp
-        ) {
-            return new Point(key, tags.orElseGet(ImmutableMap::of),
-                resource.orElseGet(ImmutableMap::of), value, timestamp);
-        }
     }
 }

--- a/api/src/main/java/com/spotify/ffwd/util/BatchMetricConverter.java
+++ b/api/src/main/java/com/spotify/ffwd/util/BatchMetricConverter.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 public class BatchMetricConverter {
-    public static Metric convertBatchMetric(final Batch batch, final Batch.Point point) {
+    public static Metric convertBatchMetric(final Batch batch, final Metric point) {
         final Map<String, String> allTags = new HashMap<>(batch.getCommonTags());
         allTags.putAll(point.getTags());
 

--- a/api/src/main/java/com/spotify/ffwd/util/HighFrequencyDetector.java
+++ b/api/src/main/java/com/spotify/ffwd/util/HighFrequencyDetector.java
@@ -97,7 +97,7 @@ public class HighFrequencyDetector {
     // {metric1 -> -1, metric2 -> 10}
     Map<Metric, Integer> groupedMetrics =
         metrics.stream()
-            .sorted(Comparator.comparing(Metric::getTime))
+            .sorted(Comparator.comparing(Metric::getTimestamp))
             .collect(
                 Collectors.groupingBy(
                     Function.identity(),
@@ -128,8 +128,8 @@ public class HighFrequencyDetector {
         .map(
             x ->
                 (int)
-                    (list.get(size - x).getTime()
-                        - list.get(size - x - 1).getTime()))
+                    (list.get(size - x).getTimestamp()
+                        - list.get(size - x - 1).getTimestamp()))
         .filter(d -> (d >= 0 && d < minFrequencyMillisAllowed))
         .summaryStatistics();
 

--- a/api/src/test/java/com/spotify/ffwd/model/v2/TestBatch.java
+++ b/api/src/test/java/com/spotify/ffwd/model/v2/TestBatch.java
@@ -82,43 +82,51 @@ public class TestBatch {
     private com.spotify.ffwd.model.v2.Batch createBatch
         (final Map<String,String>commonTags, final Map<String,String> commonResources){
         ByteString byteString = ByteString.copyFromUtf8("addddesgeagtept");
-        Batch.Point p1 = createPoint(byteString);
-        Batch.Point p2 = createPoint(600.56);
-        List<Batch.Point> points = new ArrayList<>();
+        Metric p1 = createPoint(byteString);
+        Metric p2 = createPoint(600.56);
+        List<Metric> points = new ArrayList<>();
         points.add(p1);
         points.add(p2);
-        return new com.spotify.ffwd.model.v2.Batch(commonTags,commonResources,points);
+        return new com.spotify.ffwd.model.v2.Batch(commonTags, commonResources, points);
     }
 
 
-    private  Batch.Point createPoint(final Double val){
-        Optional<Map<String, String>> tag1 = Optional.of(new HashMap<String, String>() {{
+    private Metric createPoint(final Double val){
+        Map<String, String> tags = new HashMap<String, String>() {{
             put("what", "cpu-used-percentage");
             put("units", "%");
-        }});
+        }};
 
-        Optional<Map<String,String>> resource =
-            Optional.of(Collections.singletonMap("instance","instance_point1"));
+        Map<String,String> resource = Collections.singletonMap("instance","instance_point1");
 
         Value.DoubleValue val1 = com.spotify.ffwd.model.v2.Value.DoubleValue.create(val);
 
-        return  Batch.Point.create("distribution-test",tag1,resource,val1,
-            System.currentTimeMillis());
+        return Metric.builder()
+            .setKey("distribution-test")
+            .setValue(val1)
+            .setTimestamp(System.currentTimeMillis())
+            .setTags(tags)
+            .setResource(resource)
+            .build();
     }
 
-    private static Batch.Point createPoint(final ByteString val){
-        Optional<Map<String, String>> tag1 = Optional.of(new HashMap<String, String>() {{
+    private static Metric createPoint(final ByteString val){
+        Map<String, String> tags = new HashMap<String, String>() {{
             put("what", "cpu-used-percentage");
             put("units", "%");
-        }});
-        Optional<Map<String,String>> resource =
-            Optional.of(Collections.singletonMap("instance","instance_point1"));
+        }};
+        Map<String,String> resource = Collections.singletonMap("instance","instance_point1");
 
         Value.DistributionValue val1 =
             com.spotify.ffwd.model.v2.Value.DistributionValue.create(val);
 
-        return Batch.Point.create("distribution-test",tag1,resource,val1,
-            System.currentTimeMillis());
+        return Metric.builder()
+            .setKey("distribution-test")
+            .setValue(val1)
+            .setTimestamp(System.currentTimeMillis())
+            .setTags(tags)
+            .setResource(resource)
+            .build();
     }
 
     private String readResources(final String name) throws IOException {

--- a/core/src/main/java/com/spotify/ffwd/generated/GeneratedInputPlugin.java
+++ b/core/src/main/java/com/spotify/ffwd/generated/GeneratedInputPlugin.java
@@ -25,19 +25,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.PrivateModule;
-import com.spotify.ffwd.filter.Filter;
 import com.spotify.ffwd.input.InputPlugin;
 import com.spotify.ffwd.input.PluginSource;
 import java.util.Optional;
 
 public class GeneratedInputPlugin implements InputPlugin {
     private final boolean sameHost;
+    private final int count;
 
     @JsonCreator
     public GeneratedInputPlugin(
-        @JsonProperty("sameHost") Boolean sameHost, @JsonProperty("filter") Optional<Filter> filter
+        @JsonProperty("sameHost") Optional<Boolean> sameHost,
+        @JsonProperty("count") Optional<Integer> count
     ) {
-        this.sameHost = Optional.ofNullable(sameHost).orElse(false);
+        this.sameHost = sameHost.orElse(false);
+        this.count = count.orElse(10000);
     }
 
     @Override
@@ -45,7 +47,7 @@ public class GeneratedInputPlugin implements InputPlugin {
         return new PrivateModule() {
             @Override
             protected void configure() {
-                bind(key).toInstance(new GeneratedPluginSource(sameHost));
+                bind(key).toInstance(new GeneratedPluginSource(sameHost, count));
                 expose(key);
             }
         };

--- a/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
+++ b/core/src/main/java/com/spotify/ffwd/generated/GeneratedPluginSource.java
@@ -26,27 +26,20 @@ import com.spotify.ffwd.input.InputManager;
 import com.spotify.ffwd.input.PluginSource;
 import com.spotify.ffwd.model.v2.Metric;
 import com.spotify.ffwd.model.v2.Value;
-import com.spotify.ffwd.output.OutputManager;
 import eu.toolchain.async.AsyncFramework;
 import eu.toolchain.async.AsyncFuture;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class GeneratedPluginSource implements PluginSource {
     @Inject
     private AsyncFramework async;
-
     @Inject
     private InputManager input;
-    @Inject
-    private OutputManager output;
-
-    private final int count = 10000;
 
     private volatile AsyncFuture<Void> task;
     private volatile List<Metric> metrics;
@@ -56,30 +49,26 @@ public class GeneratedPluginSource implements PluginSource {
     private final ExecutorService single = Executors.newSingleThreadExecutor();
 
     private final boolean sameHost;
+    private final int count;
 
-    public GeneratedPluginSource(boolean sameHost) {
+    GeneratedPluginSource(boolean sameHost, int count) {
         this.sameHost = sameHost;
+        this.count = count;
     }
 
     @Override
     public void init() {
-        task = async.call(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                generate();
-                return null;
-            }
+        task = async.call(() -> {
+            generate();
+            return null;
         }, single);
     }
 
     @Override
     public AsyncFuture<Void> start() {
-        return async.call(new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                metrics = generateMetrics();
-                return null;
-            }
+        return async.call(() -> {
+            metrics = generateMetrics();
+            return null;
         });
     }
 

--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -363,8 +363,8 @@ public class CoreOutputManager implements OutputManager {
      * Filter the provided Metric and complete fields.
      */
     private Metric filter(final Metric metric) {
-        final long time = metric.getTime() != 0 ?
-                metric.getTime() : System.currentTimeMillis();
+        final long time = metric.getTimestamp() != 0 ?
+                          metric.getTimestamp() : System.currentTimeMillis();
 
         final Map<String, String> tags = selectTags(metric);
         final Map<String, String> commonResource = Maps.newHashMap(resource);
@@ -394,7 +394,7 @@ public class CoreOutputManager implements OutputManager {
         final Map<String, String> mergedCommonTags = tagsAndResources.getKey();
         final Map<String, String> mergedCommonResource = tagsAndResources.getValue();
 
-        final List<Batch.Point> points = batch.getPoints().stream().map(point -> {
+        final List<Metric> points = batch.getPoints().stream().map(point -> {
             final Map<String, String> pointTags = point.getTags();
             final Map<String, String> pointResource = point.getResource();
 
@@ -403,13 +403,13 @@ public class CoreOutputManager implements OutputManager {
             final Map<String, String> mergedTags = pointTagsAndResources.getKey();
             final Map<String, String> mergedResource = pointTagsAndResources.getValue();
 
-            return new Batch.Point(
-                point.getKey(),
-                mergedTags,
-                mergedResource,
-                point.getValue(),
-                point.getTimestamp());
-
+            return Metric.builder()
+                .setKey(point.getKey())
+                .setTags(mergedTags)
+                .setResource(mergedResource)
+                .setValue(point.getValue())
+                .setTimestamp(point.getTimestamp())
+                .build();
         }).collect(Collectors.toList());
 
         return new Batch(mergedCommonTags, mergedCommonResource, points);

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100ProtoSerializer.java
@@ -78,7 +78,7 @@ public class Spotify100ProtoSerializer implements Serializer {
         Spotify100.Metric.Builder builder = Spotify100.Metric.newBuilder();
         builder.setKey(metric.getKey())
             .setDistributionTypeValue(valueBuilder.build())
-            .setTime(metric.getTime())
+            .setTime(metric.getTimestamp())
             .putAllTags(metric.getTags())
             .putAllResource(metric.getResource())
             .build();

--- a/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
+++ b/core/src/main/java/com/spotify/ffwd/serializer/Spotify100Serializer.java
@@ -67,7 +67,7 @@ public class Spotify100Serializer implements Serializer {
     @Override
     public byte[] serialize(Metric source) throws Exception {
         final Spotify100Metric m =
-            new Spotify100Metric(source.getKey(), source.getTime(),
+            new Spotify100Metric(source.getKey(), source.getTimestamp(),
                 source.getTags(), source.getResource(), source.getValue());
         return mapper.writeValueAsBytes(m);
     }

--- a/core/src/test/java/com/spotify/ffwd/util/BatchMetricConverterTest.java
+++ b/core/src/test/java/com/spotify/ffwd/util/BatchMetricConverterTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.ffwd.model.v2.Batch;
-import com.spotify.ffwd.model.v2.Batch.Point;
 import com.spotify.ffwd.model.v2.Metric;
 import com.spotify.ffwd.model.v2.Value;
 import java.util.List;
@@ -36,25 +35,30 @@ import org.junit.Test;
 
 
 public class BatchMetricConverterTest {
-    public Map<String, String> baseTags;
-    public Map<String, String> baseResources;
-    public Map<String, String> commonTags;
-    public Map<String, String> commonResources;
-    public Batch.Point point1;
+    private Map<String, String> baseTags;
+    private Map<String, String> baseResources;
+    private Map<String, String> commonTags;
+    private Map<String, String> commonResources;
+    private Metric point;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         baseTags = ImmutableMap.of("tag1", "v1", "tag2", "v2");
         baseResources = ImmutableMap.of("resource1", "v1", "resource2", "v2");
         commonTags = ImmutableMap.of("ctag1", "1", "ctag2", "2", "ctag3", "3");
         commonResources = ImmutableMap.of("cResource1", "1", "cResource2", "2");
-        point1 = Batch.Point.create("test", Optional.of(baseTags), Optional.of(baseResources), Value.DoubleValue.create(5), 0);
-
+        point = Metric.builder()
+            .setKey("test")
+            .setTags(baseTags)
+            .setResource(baseResources)
+            .setValue(Value.DoubleValue.create(5))
+            .setTimestamp(0)
+            .build();
     }
 
     @Test
-    public void convertBatchMetric() throws Exception {
-        final ImmutableList<Point> points = ImmutableList.of(point1);
+    public void convertBatchMetric() {
+        final ImmutableList<Metric> points = ImmutableList.of(point);
         final Batch batch = Batch.create(Optional.of(commonTags), Optional.of(commonResources), points);
         final Metric metric = BatchMetricConverter.convertBatchMetric(batch, points.get(0));
 
@@ -69,15 +73,17 @@ public class BatchMetricConverterTest {
     }
 
     @Test
-    public void testConvertBatchesToMetrics() throws Exception {
-        final Batch batch1 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of(point1));
-        final Batch batch2 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of(point1));
+    public void testConvertBatchesToMetrics() {
+        final Batch batch1 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of(
+            point));
+        final Batch batch2 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of(
+            point));
         final List<Metric> results = BatchMetricConverter.convertBatchesToMetrics(ImmutableList.of(batch1, batch2));
         assertEquals(2, results.size());
     }
 
     @Test
-    public void convertBatchesToMetricsEmptyPoints() throws Exception {
+    public void convertBatchesToMetricsEmptyPoints() {
         final Batch batch1 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of());
         final Batch batch2 = Batch.create(Optional.of(commonTags), Optional.of(commonResources), ImmutableList.of());
         final List<Metric> results = BatchMetricConverter.convertBatchesToMetrics(ImmutableList.of(batch1, batch2));
@@ -85,7 +91,7 @@ public class BatchMetricConverterTest {
     }
 
     @Test
-    public void convertBatchesToMetricsEmptyBatch() throws Exception {
+    public void convertBatchesToMetricsEmptyBatch() {
         final List<Metric> results = BatchMetricConverter.convertBatchesToMetrics(ImmutableList.of());
         assertEquals(0, results.size());
     }

--- a/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
+++ b/modules/http/src/main/java/com/spotify/ffwd/http/HttpPluginSink.java
@@ -91,11 +91,7 @@ public class HttpPluginSink implements BatchablePluginSink {
 
     @Override
     public AsyncFuture<Void> sendMetrics(final Collection<Metric> metrics) {
-        final List<Batch.Point> out = new ArrayList<>();
-
-        for (final Metric m : metrics) {
-            out.add(m.toBatchPoint());
-        }
+        final List<Metric> out = new ArrayList<>(metrics);
 
         // creates a new batch _without_ common tags, prefer using sendBatches instead.
         final Batch b = new Batch(ImmutableMap.of(), ImmutableMap.of(), out);

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaPluginSink.java
@@ -97,7 +97,7 @@ public class KafkaPluginSink implements BatchablePluginSink {
     }
 
     private KeyedMessage<Integer, byte[]> convertBatchMetric(
-        final Batch batch, final Batch.Point point
+        final Batch batch, final Metric point
     ) throws Exception {
         final Map<String, String> allTags = new HashMap<>(batch.getCommonTags());
         allTags.putAll(point.getTags());
@@ -177,7 +177,7 @@ public class KafkaPluginSink implements BatchablePluginSink {
         return Iterators.partition(iterator, batchSize);
     }
 
-    final Converter<Metric> metricConverter = new Converter<Metric>() {
+    private final Converter<Metric> metricConverter = new Converter<Metric>() {
         @Override
         public KeyedMessage<Integer, byte[]> toMessage(final Metric metric) throws Exception {
             final String topic = router.route(metric);

--- a/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaRouter.java
+++ b/modules/kafka/src/main/java/com/spotify/ffwd/kafka/KafkaRouter.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.spotify.ffwd.model.v2.Batch;
 import com.spotify.ffwd.model.v2.Metric;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -36,8 +35,6 @@ import java.util.function.Supplier;
 })
 public interface KafkaRouter {
     String route(final Metric metric);
-
-    String route(final Batch.Point point);
 
     class Tag implements KafkaRouter {
         private static final String DEFAULT = "default";
@@ -67,17 +64,6 @@ public interface KafkaRouter {
             return String.format(metrics, DEFAULT);
         }
 
-        @Override
-        public String route(final Batch.Point point) {
-            final String tagValue = point.getTags().get(tagKey);
-
-            if (tagValue != null) {
-                return String.format(metrics, tagValue);
-            }
-
-            return String.format(metrics, DEFAULT);
-        }
-
         static Supplier<KafkaRouter> supplier() {
             return () -> new Tag(null, null);
         }
@@ -95,11 +81,6 @@ public interface KafkaRouter {
 
         @Override
         public String route(final Metric metric) {
-            return metrics;
-        }
-
-        @Override
-        public String route(final Batch.Point point) {
             return metrics;
         }
     }

--- a/modules/opentelemetry/src/main/java/com/spotify/ffwd/opentelemetry/OpenTelemetryPluginSink.java
+++ b/modules/opentelemetry/src/main/java/com/spotify/ffwd/opentelemetry/OpenTelemetryPluginSink.java
@@ -154,7 +154,7 @@ public class OpenTelemetryPluginSink implements PluginSink {
         return DoubleGauge.newBuilder()
             .addDataPoints(DoubleDataPoint.newBuilder()
                 .setStartTimeUnixNano(0)
-                .setTimeUnixNano(metric.getTime() * 1000 * 1000)
+                .setTimeUnixNano(metric.getTimestamp() * 1000 * 1000)
                 .setValue((Double) metric.getValue().getValue())
                 .addAllLabels(labels)
                 .build())

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
@@ -118,7 +118,7 @@ public class PubsubPluginSink implements BatchablePluginSink {
       final ByteString m = ByteString.copyFrom(serializer.serialize(metrics, writeCache));
       publishPubSub(m);
     } catch (Exception e) {
-      logger.error("Failed to serialize batch of metrics {}", e);
+      logger.error("Failed to serialize batch of metrics: ", e);
     }
     return async.resolved();
   }

--- a/modules/pubsub/src/test/java/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
+++ b/modules/pubsub/src/test/java/com/spotify/ffwd/pubsub/PubsubPluginSinkTest.java
@@ -89,9 +89,11 @@ public class PubsubPluginSinkTest {
 
     @Test
     public void testSendBatch() {
-        final Batch batch = Batch.create(Optional.of(ImmutableMap.of("tag1", "foo")),
-            Optional.of(ImmutableMap.of("resource", "foo")),
-            ImmutableList.of(metric.toBatchPoint()));
+        final Batch batch = new Batch(
+            ImmutableMap.of("tag1", "foo"),
+            ImmutableMap.of("resource", "foo"),
+            ImmutableList.of(metric)
+        );
 
         sink.sendBatch(batch);
         verify(publisher).publish(isA(PubsubMessage.class));

--- a/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxPluginSink.java
+++ b/modules/signalfx/src/main/java/com/spotify/ffwd/signalfx/SignalFxPluginSink.java
@@ -97,7 +97,7 @@ public class SignalFxPluginSink implements BatchablePluginSink {
                             .setValue(SignalFxProtocolBuffers.Datum
                                 .newBuilder()
                                 .setDoubleValue(getDoubleDataPoint(metric)))
-                            .setTimestamp(metric.getTime());
+                            .setTimestamp(metric.getTimestamp());
 
                     metric
                         .getTags()


### PR DESCRIPTION
Batch.Point and Metric have almost the exact same definition, the only significant differences were that Batch.Point has a JSON constructor and uses `timestamp` instead of `time`. I refactored to only use Metrics across ffwd.

Unrelated small change that I'm combining in this PR is to make the GeneratedPluginSource count configurable.