### PR TITLE
Run checkstyle in all maven environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,57 +78,6 @@
 
   <profiles>
     <profile>
-      <id>checkstyle</id>
-
-      <activation>
-        <property>
-          <name>environment</name>
-          <value>test</value>
-        </property>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-checkstyle-plugin</artifactId>
-            <version>3.0.0</version>
-            <configuration>
-              <configLocation>checkstyle.xml</configLocation>
-              <consoleOutput>true</consoleOutput>
-              <failOnViolation>true</failOnViolation>
-              <failsOnError>true</failsOnError>
-              <maxAllowedViolations>0</maxAllowedViolations>
-              <propertyExpansion>basedir=${user.dir}</propertyExpansion>
-            </configuration>
-            <executions>
-              <execution>
-                <id>validate-checkstyle</id>
-
-                <phase>validate</phase>
-
-                <goals>
-                  <goal>check</goal>
-                </goals>
-                <configuration>
-                  <failOnViolation>true</failOnViolation>
-                  <failsOnError>true</failsOnError>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>com.puppycrawl.tools</groupId>
-                <artifactId>checkstyle</artifactId>
-                <version>8.18</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>jdk8</id>
       <activation>
         <jdk>1.8</jdk>
@@ -663,6 +612,40 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <configLocation>checkstyle.xml</configLocation>
+          <consoleOutput>true</consoleOutput>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+          <maxAllowedViolations>0</maxAllowedViolations>
+          <propertyExpansion>basedir=${user.dir}</propertyExpansion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate-checkstyle</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <failOnViolation>true</failOnViolation>
+              <failsOnError>true</failsOnError>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.18</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Removing the profile makes checkstyle run in every `validate` phase, instead of only when the environment is explicitly set to test. This makes it easier to catch style issues locally.