### PR TITLE
Revert Docker image to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3.5.4-jdk-8 as builder
+FROM maven:3.5.4-jdk-11 as builder
 COPY . .
 RUN mvn clean package
 RUN mv agent/target/ffwd-agent-*.jar agent/target/ffwd-full.jar
 
 # final image
-FROM openjdk:8-slim-stretch
+FROM openjdk:11-slim-stretch
 
 EXPOSE 19091/udp
 EXPOSE 19000/tcp
@@ -17,4 +17,3 @@ CMD ["/etc/ffwd/ffwd.yaml"]
 COPY --from=0 agent/target/ffwd-full.jar /usr/share/ffwd/ffwd-full.jar
 COPY agent/ffwd.yaml /etc/ffwd/ffwd.yaml
 COPY agent/ffwd /usr/bin/ffwd
-


### PR DESCRIPTION
All the Docker Hub builds are failing since the base image was switched to 8. AFAIK there's no reason to use 8 in Docker since it would be totally independent from any projects requiring Java 8 (@lmuhlha correct me if I'm wrong) so I'm switching it back to 11.