### PR TITLE
[CoreOutputManager] Check if points are null before getting key

### DIFF
--- a/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
+++ b/core/src/main/java/com/spotify/ffwd/output/CoreOutputManager.java
@@ -274,8 +274,10 @@ public class CoreOutputManager implements OutputManager {
 
     statistics.reportMetricsCardinality(hyperLog.get().cardinality());
 
-    if (isDroppable(batchSize, batch.getPoints().get(0).getKey())) {
-      return;
+    if (batch.getPoints().size() > 0) {
+      if (isDroppable(batchSize, batch.getPoints().get(0).getKey())) {
+        return;
+      }
     }
 
     sinks.stream()

--- a/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
+++ b/modules/pubsub/src/main/java/com/spotify/ffwd/pubsub/PubsubPluginSink.java
@@ -123,7 +123,7 @@ public class PubsubPluginSink implements BatchablePluginSink {
       final ByteString m = ByteString.copyFrom(serializer.serialize(metrics, writeCache));
 
       if (m.size() > MAX_BATCH_SIZE_BYTES) {
-        logger.warn("Above byte limit, resizing batch");
+        logger.info("Above byte limit, resizing batch");
         int times = (int)Math.ceil(m.size()/MAX_BATCH_SIZE_BYTES);
         List<List<Metric>> collections = Lists.partition(new ArrayList<>(metrics), metrics.size()/times);
         for (List<Metric> l: collections) {


### PR DESCRIPTION
Remediates ```java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:372)
	at java.base/java.util.ArrayList.get(ArrayList.java:459)
	at com.spotify.ffwd.output.CoreOutputManager.sendBatch(CoreOutputManager.java:277)
	at com.spotify.ffwd.input.CoreInputManager.receiveBatch(CoreInputManager.java:89)
	at com.spotify.ffwd.input.InputChannelInboundHandler.channelRead(InputChannelInboundHandler.java:48)```